### PR TITLE
Increase max body size nginx

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -4,6 +4,9 @@ events {
     worker_connections 1024;
 }
 http {
+
+    client_max_body_size 300M;
+
     server {
         listen 5555;
         location ~* ^/proxy/(\d+)(.*)$ {


### PR DESCRIPTION
Tests for file upload fails.
Default value for nginx is 1M.
So when upload more you get 413 error.
300M shuold be enough for everyone ;)

But further it's better to make configurable