### PR TITLE
Supporting 'latest' for docker-selenium nodes

### DIFF
--- a/src/main/java/de/zalando/tip/zalenium/proxy/BrowserStackRemoteProxy.java
+++ b/src/main/java/de/zalando/tip/zalenium/proxy/BrowserStackRemoteProxy.java
@@ -6,12 +6,10 @@ import com.google.gson.JsonObject;
 import de.zalando.tip.zalenium.util.TestInformation;
 import org.openqa.grid.common.RegistrationRequest;
 import org.openqa.grid.internal.Registry;
-import org.openqa.grid.internal.TestSession;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.remote.BrowserType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
-import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/src/main/java/de/zalando/tip/zalenium/proxy/BrowserStackRemoteProxy.java
+++ b/src/main/java/de/zalando/tip/zalenium/proxy/BrowserStackRemoteProxy.java
@@ -92,12 +92,6 @@ public class BrowserStackRemoteProxy extends CloudTestingRemoteProxy {
     }
 
     @Override
-    public TestSession getNewSession(Map<String, Object> requestedCapability) {
-        logger.log(Level.INFO, "[BS] Test will be forwarded to Browser Stack, {0}.", requestedCapability);
-        return super.getNewSession(requestedCapability);
-    }
-
-    @Override
     public String getUserNameProperty() {
         return "browserstack.user";
     }

--- a/src/main/java/de/zalando/tip/zalenium/proxy/CloudTestingRemoteProxy.java
+++ b/src/main/java/de/zalando/tip/zalenium/proxy/CloudTestingRemoteProxy.java
@@ -96,7 +96,7 @@ public class CloudTestingRemoteProxy extends DefaultRemoteProxy {
                 JsonObject desiredCapabilities = jsonObject.getAsJsonObject("desiredCapabilities");
                 desiredCapabilities.addProperty(getUserNameProperty(), getUserNameValue());
                 desiredCapabilities.addProperty(getAccessKeyProperty(), getAccessKeyValue());
-                if (!desiredCapabilities.has(CapabilityType.VERSION)) {
+                if (!desiredCapabilities.has(CapabilityType.VERSION) && proxySupportsLatestAsCapability()) {
                     desiredCapabilities.addProperty(CapabilityType.VERSION, "latest");
                 }
                 seleniumRequest.setBody(jsonObject.toString());
@@ -149,6 +149,10 @@ public class CloudTestingRemoteProxy extends DefaultRemoteProxy {
 
     public String getVideoFileExtension() {
         return null;
+    }
+
+    public boolean proxySupportsLatestAsCapability() {
+        return false;
     }
 
     public void addTestToDashboard(String seleniumSessionId) {

--- a/src/main/java/de/zalando/tip/zalenium/proxy/CloudTestingRemoteProxy.java
+++ b/src/main/java/de/zalando/tip/zalenium/proxy/CloudTestingRemoteProxy.java
@@ -16,6 +16,7 @@ import org.openqa.grid.internal.utils.CapabilityMatcher;
 import org.openqa.grid.selenium.proxy.DefaultRemoteProxy;
 import org.openqa.grid.web.servlet.handler.RequestType;
 import org.openqa.grid.web.servlet.handler.WebDriverRequest;
+import org.openqa.selenium.remote.CapabilityType;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -95,6 +96,9 @@ public class CloudTestingRemoteProxy extends DefaultRemoteProxy {
                 JsonObject desiredCapabilities = jsonObject.getAsJsonObject("desiredCapabilities");
                 desiredCapabilities.addProperty(getUserNameProperty(), getUserNameValue());
                 desiredCapabilities.addProperty(getAccessKeyProperty(), getAccessKeyValue());
+                if (!desiredCapabilities.has(CapabilityType.VERSION)) {
+                    desiredCapabilities.addProperty(CapabilityType.VERSION, "latest");
+                }
                 seleniumRequest.setBody(jsonObject.toString());
             }
         }

--- a/src/main/java/de/zalando/tip/zalenium/proxy/CloudTestingRemoteProxy.java
+++ b/src/main/java/de/zalando/tip/zalenium/proxy/CloudTestingRemoteProxy.java
@@ -21,6 +21,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -76,6 +77,12 @@ public class CloudTestingRemoteProxy extends DefaultRemoteProxy {
     @VisibleForTesting
     static void restoreEnvironment() {
         env = defaultEnvironment;
+    }
+
+    @Override
+    public TestSession getNewSession(Map<String, Object> requestedCapability) {
+        logger.log(Level.INFO, () ->"Test will be forwarded to " + getProxyName() + ", " + requestedCapability);
+        return super.getNewSession(requestedCapability);
     }
 
     @Override

--- a/src/main/java/de/zalando/tip/zalenium/proxy/SauceLabsRemoteProxy.java
+++ b/src/main/java/de/zalando/tip/zalenium/proxy/SauceLabsRemoteProxy.java
@@ -75,12 +75,6 @@ public class SauceLabsRemoteProxy extends CloudTestingRemoteProxy {
     }
 
     @Override
-    public TestSession getNewSession(Map<String, Object> requestedCapability) {
-        LOGGER.log(Level.INFO, "[SL] Test will be forwarded to Sauce Labs, {0}.", requestedCapability);
-        return super.getNewSession(requestedCapability);
-    }
-
-    @Override
     public String getUserNameProperty() {
         return "username";
     }

--- a/src/main/java/de/zalando/tip/zalenium/proxy/SauceLabsRemoteProxy.java
+++ b/src/main/java/de/zalando/tip/zalenium/proxy/SauceLabsRemoteProxy.java
@@ -98,6 +98,11 @@ public class SauceLabsRemoteProxy extends CloudTestingRemoteProxy {
     }
 
     @Override
+    public boolean proxySupportsLatestAsCapability() {
+        return true;
+    }
+
+    @Override
     public TestInformation getTestInformation(String seleniumSessionId) {
         // https://SL_USER:SL_KEY@saucelabs.com/rest/v1/SL_USER/jobs/SELENIUM_SESSION_ID
         String sauceLabsVideoUrl = "https://%s:%s@saucelabs.com/rest/v1/%s/jobs/%s/assets/video.flv";

--- a/src/main/java/de/zalando/tip/zalenium/proxy/SauceLabsRemoteProxy.java
+++ b/src/main/java/de/zalando/tip/zalenium/proxy/SauceLabsRemoteProxy.java
@@ -6,11 +6,9 @@ import com.google.gson.JsonObject;
 import de.zalando.tip.zalenium.util.TestInformation;
 import org.openqa.grid.common.RegistrationRequest;
 import org.openqa.grid.internal.Registry;
-import org.openqa.grid.internal.TestSession;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/src/main/java/de/zalando/tip/zalenium/proxy/TestingBotRemoteProxy.java
+++ b/src/main/java/de/zalando/tip/zalenium/proxy/TestingBotRemoteProxy.java
@@ -6,11 +6,9 @@ import com.google.gson.JsonObject;
 import de.zalando.tip.zalenium.util.TestInformation;
 import org.openqa.grid.common.RegistrationRequest;
 import org.openqa.grid.internal.Registry;
-import org.openqa.grid.internal.TestSession;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
-import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/src/main/java/de/zalando/tip/zalenium/proxy/TestingBotRemoteProxy.java
+++ b/src/main/java/de/zalando/tip/zalenium/proxy/TestingBotRemoteProxy.java
@@ -90,6 +90,11 @@ public class TestingBotRemoteProxy extends CloudTestingRemoteProxy {
     }
 
     @Override
+    public boolean proxySupportsLatestAsCapability() {
+        return true;
+    }
+
+    @Override
     public TestInformation getTestInformation(String seleniumSessionId) {
         // https://TB_KEY:TB_SECRET@api.testingbot.com/v1/tests/SELENIUM_SESSION_ID
         TestInformation testInformation = null;

--- a/src/main/java/de/zalando/tip/zalenium/proxy/TestingBotRemoteProxy.java
+++ b/src/main/java/de/zalando/tip/zalenium/proxy/TestingBotRemoteProxy.java
@@ -67,12 +67,6 @@ public class TestingBotRemoteProxy extends CloudTestingRemoteProxy {
     }
 
     @Override
-    public TestSession getNewSession(Map<String, Object> requestedCapability) {
-        logger.log(Level.INFO, "[TB] Test will be forwarded to TestingBot, {0}.", requestedCapability);
-        return super.getNewSession(requestedCapability);
-    }
-
-    @Override
     public String getUserNameProperty() {
         return "key";
     }

--- a/src/main/java/de/zalando/tip/zalenium/proxy/TestingBotRemoteProxy.java
+++ b/src/main/java/de/zalando/tip/zalenium/proxy/TestingBotRemoteProxy.java
@@ -102,7 +102,6 @@ public class TestingBotRemoteProxy extends CloudTestingRemoteProxy {
             String browserVersion = testData.get("browser_version").getAsString();
             String platform = testData.get("os").getAsString();
             String videoUrl = testData.get("video").getAsString();
-            logger.info(seleniumSessionId + " - "  + videoUrl);
             testInformation = new TestInformation(seleniumSessionId, testName, getProxyName(), browser, browserVersion,
                     platform, "", getVideoFileExtension(), videoUrl);
             // Sometimes the video URL is not ready right away, so we need to wait a bit and fetch again.

--- a/src/main/java/de/zalando/tip/zalenium/util/DockerSeleniumCapabilityMatcher.java
+++ b/src/main/java/de/zalando/tip/zalenium/util/DockerSeleniumCapabilityMatcher.java
@@ -13,10 +13,6 @@ import java.util.logging.Logger;
 public class DockerSeleniumCapabilityMatcher extends DefaultCapabilityMatcher {
     private static final Logger logger = Logger.getLogger(DockerSeleniumCapabilityMatcher.class.getName());
 
-    public DockerSeleniumCapabilityMatcher() {
-        super();
-    }
-
     @Override
     public boolean matches(Map<String, Object> nodeCapability, Map<String, Object> requestedCapability) {
         logger.log(Level.FINE, ()-> String.format("Validating %s in node with capabilities %s", requestedCapability,

--- a/src/main/java/de/zalando/tip/zalenium/util/DockerSeleniumCapabilityMatcher.java
+++ b/src/main/java/de/zalando/tip/zalenium/util/DockerSeleniumCapabilityMatcher.java
@@ -1,0 +1,44 @@
+package de.zalando.tip.zalenium.util;
+
+import org.openqa.grid.internal.utils.DefaultCapabilityMatcher;
+import org.openqa.selenium.remote.CapabilityType;
+
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * The purpose of this class is to let docker-selenium process requests where a capability "version=latest" is present
+ */
+public class DockerSeleniumCapabilityMatcher extends DefaultCapabilityMatcher {
+    private static final Logger logger = Logger.getLogger(DockerSeleniumCapabilityMatcher.class.getName());
+
+    public DockerSeleniumCapabilityMatcher() {
+        super();
+    }
+
+    @Override
+    public boolean matches(Map<String, Object> nodeCapability, Map<String, Object> requestedCapability) {
+        logger.log(Level.FINE, ()-> String.format("Validating %s in node with capabilities %s", requestedCapability,
+                nodeCapability));
+
+        /*
+            If after removing 'latest', the capabilities match docker-selenium, we leave the requestedCapabilities
+            without the version. If not, we put the requested capability back in the requestedCapability object, so it
+            can be matched by any of the Cloud Testing Providers.
+         */
+        if (requestedCapability.containsKey(CapabilityType.VERSION)) {
+            String requestedVersion = requestedCapability.get(CapabilityType.VERSION).toString();
+            if ("latest".equalsIgnoreCase(requestedVersion)) {
+                requestedCapability.remove(CapabilityType.VERSION);
+                if (super.matches(nodeCapability, requestedCapability)) {
+                    return true;
+                } else {
+                    requestedCapability.put(CapabilityType.VERSION, requestedVersion);
+                    return false;
+                }
+            }
+        }
+        return super.matches(nodeCapability, requestedCapability);
+    }
+}

--- a/src/main/java/de/zalando/tip/zalenium/util/ZaleniumCapabilityMatcher.java
+++ b/src/main/java/de/zalando/tip/zalenium/util/ZaleniumCapabilityMatcher.java
@@ -12,7 +12,7 @@ import java.util.logging.Logger;
 
 /**
  * The purpose of this class is to check if the capabilities cannot be supplied by docker-selenium so they can be just
- * forwarded to Sauce Labs
+ * forwarded to the Cloud Testing Provider
  */
 
 public class ZaleniumCapabilityMatcher extends DefaultCapabilityMatcher {
@@ -41,7 +41,7 @@ public class ZaleniumCapabilityMatcher extends DefaultCapabilityMatcher {
             if ((remoteProxy instanceof DockerSeleniumStarterRemoteProxy) &&
                     remoteProxy.hasCapability(requestedCapability)) {
                 logger.log(Level.FINE, "Capability supported by docker-selenium, should not be processed by " +
-                        "Sauce Labs nor BrowserStack: {0}", requestedCapability);
+                        "a Cloud Testing Provider: {0}", requestedCapability);
                 return false;
             }
         }

--- a/src/test/java/de/zalando/tip/zalenium/it/ParallelIT.java
+++ b/src/test/java/de/zalando/tip/zalenium/it/ParallelIT.java
@@ -50,7 +50,7 @@ public class ParallelIT  {
     public static Object[][] browsersAndPlatformsWithTunnelProvider() {
         return new Object[][] {
                 new Object[]{BrowserType.CHROME, Platform.MAC, true},
-                new Object[]{BrowserType.FIREFOX, Platform.WINDOWS, true}
+                new Object[]{BrowserType.CHROME, Platform.WIN8, true}
         };
     }
 
@@ -76,6 +76,7 @@ public class ParallelIT  {
         DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
         desiredCapabilities.setCapability(CapabilityType.BROWSER_NAME, browserType);
         desiredCapabilities.setCapability(CapabilityType.PLATFORM, platform);
+        desiredCapabilities.setCapability(CapabilityType.VERSION, "latest");
         desiredCapabilities.setCapability("name", method.getName());
         if (localTesting) {
             desiredCapabilities.setCapability("tunnel", "true");

--- a/src/test/java/de/zalando/tip/zalenium/it/ParallelIT.java
+++ b/src/test/java/de/zalando/tip/zalenium/it/ParallelIT.java
@@ -76,7 +76,6 @@ public class ParallelIT  {
         DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
         desiredCapabilities.setCapability(CapabilityType.BROWSER_NAME, browserType);
         desiredCapabilities.setCapability(CapabilityType.PLATFORM, platform);
-        desiredCapabilities.setCapability(CapabilityType.VERSION, "latest");
         desiredCapabilities.setCapability("name", method.getName());
         if (localTesting) {
             desiredCapabilities.setCapability("tunnel", "true");
@@ -152,23 +151,13 @@ public class ParallelIT  {
     }
 
     @Test(dataProvider = "browsersAndPlatforms")
-    public void loadZalandoPageAndCheckTitle(String browserType, Platform platform) {
-
-        // Go to the homepage
-        getWebDriver().get("http://www.zalando.de");
-
-        // Assert that the title is the expected one
-        assertThat(getWebDriver().getTitle(), equalTo("Schuhe & Mode online kaufen | ZALANDO Online Shop"));
-    }
-
-    @Test(dataProvider = "browsersAndPlatforms")
     public void loadGooglePageAndCheckTitle(String browserType, Platform platform) {
 
         // Go to the homepage
         getWebDriver().get("http://www.google.com");
 
         // Assert that the title is the expected one
-        assertThat(getWebDriver().getTitle(), equalTo("Google"));
+        assertThat(getWebDriver().getTitle(), containsString("Google"));
     }
 
 }

--- a/src/test/java/de/zalando/tip/zalenium/proxy/DockerSeleniumStarterRemoteProxyTest.java
+++ b/src/test/java/de/zalando/tip/zalenium/proxy/DockerSeleniumStarterRemoteProxyTest.java
@@ -114,6 +114,20 @@ public class DockerSeleniumStarterRemoteProxyTest {
     }
 
     @Test
+    public void containerIsStartedWhenBrowserIsSupportedAndLatestIsUsedAsBrowserVersion() {
+
+        // Supported desired capability for the test session
+        Map<String, Object> supportedCapability = new HashMap<>();
+        supportedCapability.put(CapabilityType.BROWSER_NAME, BrowserType.CHROME);
+        supportedCapability.put(CapabilityType.PLATFORM, Platform.ANY);
+        supportedCapability.put(CapabilityType.VERSION, "latest");
+        TestSession testSession = spyProxy.getNewSession(supportedCapability);
+
+        Assert.assertNull(testSession);
+        verify(spyProxy, times(1)).startDockerSeleniumContainer(BrowserType.CHROME);
+    }
+
+    @Test
     public void containerIsStartedWhenFirefoxCapabilitiesAreSupported() {
 
         // Supported desired capability for the test session

--- a/src/test/java/de/zalando/tip/zalenium/proxy/SauceLabsRemoteProxyTest.java
+++ b/src/test/java/de/zalando/tip/zalenium/proxy/SauceLabsRemoteProxyTest.java
@@ -124,7 +124,7 @@ public class SauceLabsRemoteProxyTest {
 
         // The body should now have the SauceLabs variables
         String expectedBody = String.format("{\"desiredCapabilities\":{\"browserName\":\"internet explorer\",\"platform\":" +
-                        "\"WIN8\",\"username\":\"%s\",\"accessKey\":\"%s\"}}",
+                        "\"WIN8\",\"username\":\"%s\",\"accessKey\":\"%s\",\"version\":\"latest\"}}",
                 env.getStringEnvVariable("SAUCE_USERNAME", ""),
                 env.getStringEnvVariable("SAUCE_ACCESS_KEY", ""));
         verify(request).setBody(expectedBody);

--- a/src/test/java/de/zalando/tip/zalenium/proxy/TestingBotRemoteProxyTest.java
+++ b/src/test/java/de/zalando/tip/zalenium/proxy/TestingBotRemoteProxyTest.java
@@ -122,7 +122,7 @@ public class TestingBotRemoteProxyTest {
 
         // The body should now have the TestingBot variables
         String expectedBody = String.format("{\"desiredCapabilities\":{\"browserName\":\"internet explorer\",\"platform\":" +
-                                "\"WIN8\",\"key\":\"%s\",\"secret\":\"%s\"}}",
+                                "\"WIN8\",\"key\":\"%s\",\"secret\":\"%s\",\"version\":\"latest\"}}",
                         env.getStringEnvVariable("TESTINGBOT_KEY", ""),
                         env.getStringEnvVariable("TESTINGBOT_SECRET", ""));
         verify(request).setBody(expectedBody);


### PR DESCRIPTION
Also, sending 'latest' to any integrated cloud provider when the 'version' capability is absent.