### PR TITLE
Reset executed-tests-count if test-count-file is missing

### DIFF
--- a/src/main/java/de/zalando/tip/zalenium/util/Dashboard.java
+++ b/src/main/java/de/zalando/tip/zalenium/util/Dashboard.java
@@ -30,6 +30,11 @@ public class Dashboard {
         return executedTests;
     }
 
+    @VisibleForTesting
+    static void setExecutedTests(int executedTests) {
+        Dashboard.executedTests = executedTests;
+    }
+
     public static synchronized void updateDashboard(TestInformation testInformation) throws IOException {
         String currentLocalPath = commonProxyUtilities.currentLocalPath();
         String localVideosPath = currentLocalPath + "/" + VIDEOS_FOLDER_NAME;
@@ -60,19 +65,8 @@ public class Dashboard {
         executedTests++;
 
         File testCountFile = new File(localVideosPath, "amount_of_run_tests.txt");
-        if (testCountFile.exists()) {
-            if (isFileOlderThanOneDay(testCountFile.lastModified())) {
-                LOGGER.log(Level.FINE, "Deleting file older than one day: " + testCountFile.getAbsolutePath());
-                testCountFile.delete();
-            } else {
-                String executedTestsFromFile = FileUtils.readFileToString(testCountFile, UTF_8);
-                try {
-                    executedTests = executedTests == 1 ? Integer.parseInt(executedTestsFromFile) + 1 : executedTests;
-                } catch (Exception e) {
-                    LOGGER.log(Level.FINE, e.toString(), e);
-                }
-            }
-        }
+        synchronizeTestsCountWithFile(testCountFile);
+
         LOGGER.log(Level.FINE, "Test count: " + executedTests);
         FileUtils.writeStringToFile(testCountFile, String.valueOf(executedTests), UTF_8);
 
@@ -95,6 +89,26 @@ public class Dashboard {
         }
         if (!jsFolder.exists()) {
             FileUtils.copyDirectory(new File(currentLocalPath + "/js"), jsFolder);
+        }
+    }
+
+    @VisibleForTesting
+    static void synchronizeTestsCountWithFile(File testCountFile) throws IOException {
+        if (testCountFile.exists()) {
+            if (isFileOlderThanOneDay(testCountFile.lastModified())) {
+                LOGGER.log(Level.FINE, "Deleting file older than one day: " + testCountFile.getAbsolutePath());
+                testCountFile.delete();
+            } else {
+                String executedTestsFromFile = FileUtils.readFileToString(testCountFile, UTF_8);
+                try {
+                    executedTests = executedTests == 1 ? Integer.parseInt(executedTestsFromFile) + 1 : executedTests;
+                } catch (Exception e) {
+                    LOGGER.log(Level.FINE, e.toString(), e);
+                }
+            }
+        } else {
+            // reset executedTests if testCountFile is missing
+            executedTests = 1;
         }
     }
 

--- a/src/test/java/de/zalando/tip/zalenium/proxy/TestingBotRemoteProxyTest.java
+++ b/src/test/java/de/zalando/tip/zalenium/proxy/TestingBotRemoteProxyTest.java
@@ -64,12 +64,7 @@ public class TestingBotRemoteProxyTest {
                 DockerSeleniumStarterRemoteProxy.class.getCanonicalName());
         DockerSeleniumStarterRemoteProxy dsStarterProxy = DockerSeleniumStarterRemoteProxy.getNewInstance(request, registry);
 
-        // Temporal folder for dashboard files
-        temporaryFolder.newFile("list_template.html");
-        temporaryFolder.newFile("dashboard_template.html");
-        temporaryFolder.newFile("zalando.ico");
-        temporaryFolder.newFolder("css");
-        temporaryFolder.newFolder("js");
+        DashboardTestingSupport.ensureRequiredInputFilesExist(temporaryFolder);
 
         // We add both nodes to the registry
         registry.add(testingBotProxy);
@@ -239,10 +234,7 @@ public class TestingBotRemoteProxyTest {
             testSession.getSlot().doFinishRelease();
             spyProxy.afterCommand(testSession, request, response);
 
-            CommonProxyUtilities commonProxyUtilities = mock(CommonProxyUtilities.class);
-            when(commonProxyUtilities.currentLocalPath()).thenReturn(temporaryFolder.getRoot().getAbsolutePath());
-            when(commonProxyUtilities.getShortDateAndTime()).thenCallRealMethod();
-            Dashboard.setCommonProxyUtilities(commonProxyUtilities);
+            DashboardTestingSupport.mockCommonProxyUtilitiesForDashboardTesting(temporaryFolder);
 
             TestInformation testInformation = spyProxy.getTestInformation(mockSeleniumSessionId);
             Dashboard.updateDashboard(testInformation);
@@ -292,10 +284,7 @@ public class TestingBotRemoteProxyTest {
             testSession.getSlot().doFinishRelease();
             spyProxy.afterCommand(testSession, request, response);
 
-            CommonProxyUtilities commonProxyUtilities = mock(CommonProxyUtilities.class);
-            when(commonProxyUtilities.currentLocalPath()).thenReturn(temporaryFolder.getRoot().getAbsolutePath());
-            when(commonProxyUtilities.getShortDateAndTime()).thenCallRealMethod();
-            Dashboard.setCommonProxyUtilities(commonProxyUtilities);
+            DashboardTestingSupport.mockCommonProxyUtilitiesForDashboardTesting(temporaryFolder);
 
             TestInformation testInformation = spyProxy.getTestInformation(mockSeleniumSessionId);
             Dashboard.updateDashboard(testInformation);

--- a/src/test/java/de/zalando/tip/zalenium/util/DashboardTest.java
+++ b/src/test/java/de/zalando/tip/zalenium/util/DashboardTest.java
@@ -2,44 +2,33 @@ package de.zalando.tip.zalenium.util;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class DashboardTest {
-    private static final List<String> REQUIRED_FILES_FOR_TESTING = Arrays
-            .asList(("list_template.html,dashboard_template.html,zalando.ico").split(","));
-    private static final List<String> REQUIRED_DIRECTORIES_FOR_TESTING = Arrays.asList(("css,js").split(","));
 
     private TestInformation ti = new TestInformation("seleniumSessionId", "testName", "proxyName", "browser",
             "browserVersion", "platform");
 
-    @After
-    public void cleanCreatedEmptyResources() throws IOException {
-        for (String requiredFile : REQUIRED_FILES_FOR_TESTING) {
-            removeEmptyFile(requiredFile);
-        }
-        for (String requiredDir : REQUIRED_DIRECTORIES_FOR_TESTING) {
-            removeEmptyDir(requiredDir);
-        }
-    }
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @After
-    public void removeTestingVideosFolder() throws IOException {
-        File videos = fileWithLocalPath(Dashboard.VIDEOS_FOLDER_NAME);
-        FileUtils.deleteQuietly(videos);
+    public void restoreCommonProxyUtilities() {
+        Dashboard.restoreCommonProxyUtilities();
     }
 
     @Before
     public void initDashboard() throws IOException {
         Dashboard.setExecutedTests(0);
-        removeTestingVideosFolder();
-        ensureRequiredInputFilesExist();
+        DashboardTestingSupport.ensureRequiredInputFilesExist(temporaryFolder);
+        DashboardTestingSupport.mockCommonProxyUtilitiesForDashboardTesting(temporaryFolder);
 
         Dashboard.updateDashboard(ti);
     }
@@ -57,49 +46,13 @@ public class DashboardTest {
 
     @Test
     public void missingExecutedTestsFile() throws IOException {
-        removeTestingVideosFolder();
+        cleanTempVideosFolder();
+        DashboardTestingSupport.ensureRequiredInputFilesExist(temporaryFolder);
         Dashboard.updateDashboard(ti);
         Assert.assertEquals(1, Dashboard.getExecutedTests());
     }
 
-    private void ensureRequiredInputFilesExist() throws IOException {
-        for (String requiredFile : REQUIRED_FILES_FOR_TESTING) {
-            createEmptyFileIfMissing(requiredFile);
-        }
-        for (String requiredDir : REQUIRED_DIRECTORIES_FOR_TESTING) {
-            createEmptyDirIfMissing(requiredDir);
-        }
-    }
-
-    private void createEmptyDirIfMissing(String dirname) {
-        File toBeChecked = fileWithLocalPath(dirname);
-        if (!toBeChecked.exists()) {
-            toBeChecked.mkdir();
-        }
-    }
-
-    private File fileWithLocalPath(String name) {
-        return new File(new CommonProxyUtilities().currentLocalPath() + "/" + name);
-    }
-
-    private void createEmptyFileIfMissing(String filename) throws IOException {
-        File toBeChecked = fileWithLocalPath(filename);
-        if (!toBeChecked.exists()) {
-            toBeChecked.createNewFile();
-        }
-    }
-
-    private void removeEmptyDir(String dirname) {
-        File toBeChecked = fileWithLocalPath(dirname);
-        if (toBeChecked.exists() && toBeChecked.isDirectory() && toBeChecked.listFiles().length == 0) {
-            toBeChecked.delete();
-        }
-    }
-
-    private void removeEmptyFile(String filename) {
-        File toBeChecked = fileWithLocalPath(filename);
-        if (toBeChecked.exists() && toBeChecked.length() == 0) {
-            toBeChecked.delete();
-        }
+    private void cleanTempVideosFolder() throws IOException {
+        FileUtils.cleanDirectory(new File(temporaryFolder.getRoot().getAbsolutePath()));
     }
 }

--- a/src/test/java/de/zalando/tip/zalenium/util/DashboardTest.java
+++ b/src/test/java/de/zalando/tip/zalenium/util/DashboardTest.java
@@ -16,12 +16,8 @@ public class DashboardTest {
             .asList(("list_template.html,dashboard_template.html,zalando.ico").split(","));
     private static final List<String> REQUIRED_DIRECTORIES_FOR_TESTING = Arrays.asList(("css,js").split(","));
 
-    @Before
-    public void initDashboard() throws IOException {
-        Dashboard.setExecutedTests(0);
-        removeTestingVideosFolder();
-        ensureRequiredInputFilesExist();
-    }
+    private TestInformation ti = new TestInformation("seleniumSessionId", "testName", "proxyName", "browser",
+            "browserVersion", "platform");
 
     @After
     public void cleanCreatedEmptyResources() throws IOException {
@@ -39,39 +35,31 @@ public class DashboardTest {
         FileUtils.deleteQuietly(videos);
     }
 
-    @Test
-    public void testCountOne() throws IOException {
-        TestInformation ti = createDefaultTestInformation();
+    @Before
+    public void initDashboard() throws IOException {
+        Dashboard.setExecutedTests(0);
+        removeTestingVideosFolder();
+        ensureRequiredInputFilesExist();
 
         Dashboard.updateDashboard(ti);
+    }
 
+    @Test
+    public void testCountOne() throws IOException {
         Assert.assertEquals(1, Dashboard.getExecutedTests());
     }
 
     @Test
     public void testCountTwo() throws IOException {
-        TestInformation ti = createDefaultTestInformation();
         Dashboard.updateDashboard(ti);
-
-        Dashboard.updateDashboard(ti);
-
         Assert.assertEquals(2, Dashboard.getExecutedTests());
     }
 
     @Test
     public void missingExecutedTestsFile() throws IOException {
-        TestInformation ti = createDefaultTestInformation();
-        Dashboard.updateDashboard(ti);
         removeTestingVideosFolder();
-
         Dashboard.updateDashboard(ti);
-
         Assert.assertEquals(1, Dashboard.getExecutedTests());
-    }
-
-    private TestInformation createDefaultTestInformation() {
-        return new TestInformation("seleniumSessionId", "testName", "proxyName", "browser", "browserVersion",
-                "platform");
     }
 
     private void ensureRequiredInputFilesExist() throws IOException {

--- a/src/test/java/de/zalando/tip/zalenium/util/DashboardTest.java
+++ b/src/test/java/de/zalando/tip/zalenium/util/DashboardTest.java
@@ -1,5 +1,7 @@
 package de.zalando.tip.zalenium.util;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -12,6 +14,8 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public class DashboardTest {
+
+    public static final String TEST_COUNT_FILE_NAME = "amount_of_run_tests.txt";
 
     private TestInformation ti = new TestInformation("seleniumSessionId", "testName", "proxyName", "browser",
             "browserVersion", "platform");
@@ -50,6 +54,16 @@ public class DashboardTest {
         DashboardTestingSupport.ensureRequiredInputFilesExist(temporaryFolder);
         Dashboard.updateDashboard(ti);
         Assert.assertEquals(1, Dashboard.getExecutedTests());
+    }
+
+    @Test
+    public void nonNumberContentsIgnored() throws IOException {
+        File testCountFile = new File(temporaryFolder.getRoot().getAbsolutePath() + "/" + Dashboard.VIDEOS_FOLDER_NAME
+                + "/" + TEST_COUNT_FILE_NAME);
+        FileUtils.writeStringToFile(testCountFile, "Not-A-Number", UTF_8);
+        Dashboard.setExecutedTests(0);
+        Dashboard.updateDashboard(ti);
+        Assert.assertEquals("1", FileUtils.readFileToString(testCountFile, UTF_8));
     }
 
     private void cleanTempVideosFolder() throws IOException {

--- a/src/test/java/de/zalando/tip/zalenium/util/DashboardTest.java
+++ b/src/test/java/de/zalando/tip/zalenium/util/DashboardTest.java
@@ -12,15 +12,41 @@ import org.junit.Test;
 public class DashboardTest {
 
     @Before
-    public void initDashboard() {
+    public void initDashboard() throws IOException {
         Dashboard.setExecutedTests(0);
         removeTestingVideosFolder();
+        ensureRequiredInputFilesExist();
+    }
+
+    private void ensureRequiredInputFilesExist() throws IOException {
+        createEmptyFileIfMissing("list_template.html");
+        createEmptyFileIfMissing("dashboard_template.html");
+        createEmptyFileIfMissing("zalando.ico");
+        createEmptyDirIfMissing("css");
+        createEmptyDirIfMissing("js");
+    }
+
+    private void createEmptyDirIfMissing(String dirname) {
+        File toBeChecked = fileWithLocalPath(dirname);
+        if (!toBeChecked.exists()) {
+            toBeChecked.mkdir();
+        }
+    }
+
+    private File fileWithLocalPath(String name) {
+        return new File(new CommonProxyUtilities().currentLocalPath() + "/" + name);
+    }
+
+    private void createEmptyFileIfMissing(String filename) throws IOException {
+        File toBeChecked = fileWithLocalPath(filename);
+        if (!toBeChecked.exists()) {
+            toBeChecked.createNewFile();
+        }
     }
 
     @After
     public void removeTestingVideosFolder() {
-        String videosPath = new CommonProxyUtilities().currentLocalPath() + "/" + Dashboard.VIDEOS_FOLDER_NAME;
-        File videos = new File(videosPath);
+        File videos = fileWithLocalPath(Dashboard.VIDEOS_FOLDER_NAME);
         FileUtils.deleteQuietly(videos);
     }
 

--- a/src/test/java/de/zalando/tip/zalenium/util/DashboardTest.java
+++ b/src/test/java/de/zalando/tip/zalenium/util/DashboardTest.java
@@ -1,0 +1,61 @@
+package de.zalando.tip.zalenium.util;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DashboardTest {
+
+    @Before
+    public void initDashboard() {
+        Dashboard.setExecutedTests(0);
+        removeTestingVideosFolder();
+    }
+
+    @After
+    public void removeTestingVideosFolder() {
+        String videosPath = new CommonProxyUtilities().currentLocalPath() + "/" + Dashboard.VIDEOS_FOLDER_NAME;
+        File videos = new File(videosPath);
+        FileUtils.deleteQuietly(videos);
+    }
+
+    @Test
+    public void testCountOne() throws IOException {
+        TestInformation ti = createDefaultTestInformation();
+
+        Dashboard.updateDashboard(ti);
+
+        Assert.assertEquals(1, Dashboard.getExecutedTests());
+    }
+
+    @Test
+    public void testCountTwo() throws IOException {
+        TestInformation ti = createDefaultTestInformation();
+        Dashboard.updateDashboard(ti);
+
+        Dashboard.updateDashboard(ti);
+
+        Assert.assertEquals(2, Dashboard.getExecutedTests());
+    }
+
+    @Test
+    public void missingExecutedTestsFile() throws IOException {
+        TestInformation ti = createDefaultTestInformation();
+        Dashboard.updateDashboard(ti);
+        removeTestingVideosFolder();
+
+        Dashboard.updateDashboard(ti);
+
+        Assert.assertEquals(1, Dashboard.getExecutedTests());
+    }
+
+    private TestInformation createDefaultTestInformation() {
+        return new TestInformation("seleniumSessionId", "testName", "proxyName", "browser", "browserVersion",
+                "platform");
+    }
+}

--- a/src/test/java/de/zalando/tip/zalenium/util/DashboardTest.java
+++ b/src/test/java/de/zalando/tip/zalenium/util/DashboardTest.java
@@ -2,6 +2,8 @@ package de.zalando.tip.zalenium.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
@@ -10,6 +12,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class DashboardTest {
+    private static final List<String> REQUIRED_FILES_FOR_TESTING = Arrays
+            .asList(("list_template.html,dashboard_template.html,zalando.ico").split(","));
+    private static final List<String> REQUIRED_DIRECTORIES_FOR_TESTING = Arrays.asList(("css,js").split(","));
 
     @Before
     public void initDashboard() throws IOException {
@@ -18,34 +23,18 @@ public class DashboardTest {
         ensureRequiredInputFilesExist();
     }
 
-    private void ensureRequiredInputFilesExist() throws IOException {
-        createEmptyFileIfMissing("list_template.html");
-        createEmptyFileIfMissing("dashboard_template.html");
-        createEmptyFileIfMissing("zalando.ico");
-        createEmptyDirIfMissing("css");
-        createEmptyDirIfMissing("js");
-    }
-
-    private void createEmptyDirIfMissing(String dirname) {
-        File toBeChecked = fileWithLocalPath(dirname);
-        if (!toBeChecked.exists()) {
-            toBeChecked.mkdir();
+    @After
+    public void cleanCreatedEmptyResources() throws IOException {
+        for (String requiredFile : REQUIRED_FILES_FOR_TESTING) {
+            removeEmptyFile(requiredFile);
         }
-    }
-
-    private File fileWithLocalPath(String name) {
-        return new File(new CommonProxyUtilities().currentLocalPath() + "/" + name);
-    }
-
-    private void createEmptyFileIfMissing(String filename) throws IOException {
-        File toBeChecked = fileWithLocalPath(filename);
-        if (!toBeChecked.exists()) {
-            toBeChecked.createNewFile();
+        for (String requiredDir : REQUIRED_DIRECTORIES_FOR_TESTING) {
+            removeEmptyDir(requiredDir);
         }
     }
 
     @After
-    public void removeTestingVideosFolder() {
+    public void removeTestingVideosFolder() throws IOException {
         File videos = fileWithLocalPath(Dashboard.VIDEOS_FOLDER_NAME);
         FileUtils.deleteQuietly(videos);
     }
@@ -83,5 +72,46 @@ public class DashboardTest {
     private TestInformation createDefaultTestInformation() {
         return new TestInformation("seleniumSessionId", "testName", "proxyName", "browser", "browserVersion",
                 "platform");
+    }
+
+    private void ensureRequiredInputFilesExist() throws IOException {
+        for (String requiredFile : REQUIRED_FILES_FOR_TESTING) {
+            createEmptyFileIfMissing(requiredFile);
+        }
+        for (String requiredDir : REQUIRED_DIRECTORIES_FOR_TESTING) {
+            createEmptyDirIfMissing(requiredDir);
+        }
+    }
+
+    private void createEmptyDirIfMissing(String dirname) {
+        File toBeChecked = fileWithLocalPath(dirname);
+        if (!toBeChecked.exists()) {
+            toBeChecked.mkdir();
+        }
+    }
+
+    private File fileWithLocalPath(String name) {
+        return new File(new CommonProxyUtilities().currentLocalPath() + "/" + name);
+    }
+
+    private void createEmptyFileIfMissing(String filename) throws IOException {
+        File toBeChecked = fileWithLocalPath(filename);
+        if (!toBeChecked.exists()) {
+            toBeChecked.createNewFile();
+        }
+    }
+
+    private void removeEmptyDir(String dirname) {
+        File toBeChecked = fileWithLocalPath(dirname);
+        if (toBeChecked.exists() && toBeChecked.isDirectory() && toBeChecked.listFiles().length == 0) {
+            toBeChecked.delete();
+        }
+    }
+
+    private void removeEmptyFile(String filename) {
+        File toBeChecked = fileWithLocalPath(filename);
+        if (toBeChecked.exists() && toBeChecked.length() == 0) {
+            toBeChecked.delete();
+        }
     }
 }

--- a/src/test/java/de/zalando/tip/zalenium/util/DashboardTestingSupport.java
+++ b/src/test/java/de/zalando/tip/zalenium/util/DashboardTestingSupport.java
@@ -1,0 +1,26 @@
+package de.zalando.tip.zalenium.util;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.rules.TemporaryFolder;
+
+public class DashboardTestingSupport {
+
+    public static void mockCommonProxyUtilitiesForDashboardTesting(TemporaryFolder temporaryFolder) {
+        CommonProxyUtilities commonProxyUtilities = mock(CommonProxyUtilities.class);
+        when(commonProxyUtilities.currentLocalPath()).thenReturn(temporaryFolder.getRoot().getAbsolutePath());
+        when(commonProxyUtilities.getShortDateAndTime()).thenCallRealMethod();
+        Dashboard.setCommonProxyUtilities(commonProxyUtilities);
+    }
+
+    public static void ensureRequiredInputFilesExist(TemporaryFolder temporaryFolder) throws IOException {
+        temporaryFolder.newFile("list_template.html");
+        temporaryFolder.newFile("dashboard_template.html");
+        temporaryFolder.newFile("zalando.ico");
+        temporaryFolder.newFolder("css");
+        temporaryFolder.newFolder("js");
+    }
+}


### PR DESCRIPTION
Added an initial Dashboard Test currently only testing executedTests and changed handling of amount_of_run_tests.txt to reset executedTests. This would help if the videos folder is being cleaned (files removed) while Zalenium is still running.