### PR TITLE
Fixed grep for container id when running in DinD

### DIFF
--- a/scripts/zalenium.sh
+++ b/scripts/zalenium.sh
@@ -256,7 +256,7 @@ trap DockerTerminate SIGTERM SIGINT SIGKILL
 StartUp()
 {
     EnsureDockerWorks
-    CONTAINER_ID=$(grep docker /proc/self/cgroup | grep -o -E '[0-9a-f]{64}' | head -n 1)
+    CONTAINER_ID=$(grep docker /proc/self/cgroup | grep -o -E '[0-9a-f]{64}$' | head -n 1)
     CONTAINER_NAME=$(docker inspect ${CONTAINER_ID} | jq -r '.[0].Name' | sed 's/\///g')
     CONTAINER_LIVE_PREVIEW_PORT=$(docker inspect ${CONTAINER_ID} | jq -r '.[0].NetworkSettings.Ports."5555/tcp"' | jq -r '.[0].HostPort')
     EnsureCleanEnv


### PR DESCRIPTION
The way that the container id was previous found was broken when using zalenium with Docker in Docker, and would retrieve the DinD container's id.