### PR TITLE
Allowing --net=host in Linux 

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/container/DockerContainerClient.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/DockerContainerClient.java
@@ -206,7 +206,7 @@ public class DockerContainerClient implements ContainerClient {
                 String hostName = dockerClient.info().name();
                 extraHosts.add(String.format("%s:%s", hostName, "127.0.1.0"));
             } catch (DockerException | InterruptedException e) {
-                logger.log(Level.FINE, nodeId + " Error while starting getting host name", e);
+                logger.log(Level.FINE, nodeId + " Error while getting host name", e);
             }
         }
 

--- a/src/test/java/de/zalando/ep/zalenium/proxy/DockerSeleniumRemoteProxyTest.java
+++ b/src/test/java/de/zalando/ep/zalenium/proxy/DockerSeleniumRemoteProxyTest.java
@@ -52,7 +52,8 @@ public class DockerSeleniumRemoteProxyTest {
     @Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                {TestUtils.getMockedDockerContainerClient()}
+                {TestUtils.getMockedDockerContainerClient()},
+                {TestUtils.getMockedDockerContainerClient("host")}
         });
     }
 

--- a/src/test/java/de/zalando/ep/zalenium/proxy/DockerSeleniumStarterRemoteProxyTest.java
+++ b/src/test/java/de/zalando/ep/zalenium/proxy/DockerSeleniumStarterRemoteProxyTest.java
@@ -53,7 +53,8 @@ public class DockerSeleniumStarterRemoteProxyTest {
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                {TestUtils.getMockedDockerContainerClient()}
+                {TestUtils.getMockedDockerContainerClient()},
+                {TestUtils.getMockedDockerContainerClient("host")}
         });
     }
 

--- a/src/test/java/de/zalando/ep/zalenium/util/TestUtils.java
+++ b/src/test/java/de/zalando/ep/zalenium/util/TestUtils.java
@@ -204,6 +204,8 @@ public class TestUtils {
         when(zalenium.status()).thenReturn("running");
         when(zalenium.image()).thenReturn("dosel/zalenium");
 
+        Info dockerInfo = mock(Info.class);
+        when(dockerInfo.name()).thenReturn("ubuntu_vm");
 
         try {
             URL logsLocation = TestUtils.class.getClassLoader().getResource("logs.tar");
@@ -225,6 +227,8 @@ public class TestUtils {
 
             when(dockerClient.execStart(anyString())).thenReturn(logStream);
             doNothing().when(dockerClient).stopContainer(anyString(), anyInt());
+
+            when(dockerClient.info()).thenReturn(dockerInfo);
 
             when(dockerClient.createContainer(any(ContainerConfig.class), anyString())).thenReturn(containerCreation);
 

--- a/src/test/java/de/zalando/ep/zalenium/util/TestUtils.java
+++ b/src/test/java/de/zalando/ep/zalenium/util/TestUtils.java
@@ -152,8 +152,12 @@ public class TestUtils {
         temporaryFolder.newFile("videos/dashboard.html");
     }
 
-    @SuppressWarnings("ConstantConditions")
     public static DockerContainerClient getMockedDockerContainerClient() {
+        return getMockedDockerContainerClient("default");
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    public static DockerContainerClient getMockedDockerContainerClient(String networkName) {
         DockerClient dockerClient = mock(DockerClient.class);
         ExecCreation execCreation = mock(ExecCreation.class);
         LogStream logStream = mock(LogStream.class);
@@ -177,7 +181,7 @@ public class TestUtils {
         when(homeFolderMount.source()).thenReturn("/tmp/folder");
         when(containerInfo.mounts()).thenReturn(ImmutableList.of(tmpMountedMount, homeFolderMount));
         when(attachedNetwork.ipAddress()).thenReturn("127.0.0.1");
-        when(networkSettings.networks()).thenReturn(ImmutableMap.of("default", attachedNetwork));
+        when(networkSettings.networks()).thenReturn(ImmutableMap.of(networkName, attachedNetwork));
         when(networkSettings.ipAddress()).thenReturn("");
         when(containerInfo.networkSettings()).thenReturn(networkSettings);
 


### PR DESCRIPTION
and including `mac.host.local` to the hosts file to allow access to the host in OSX. In theory `docker.for.mac.localhost` should have worked but somehow it is not working for Chrome.