### PR TITLE
reflect extraHosts of the hub container to node containers

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/container/DockerContainerClient.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/DockerContainerClient.java
@@ -306,15 +306,13 @@ public class DockerContainerClient implements ContainerClient {
         try {
             containerInfo = dockerClient.inspectContainer(containerId);
             zaleniumExtraHosts = containerInfo.hostConfig().extraHosts();
-            if (zaleniumExtraHosts == null) {
-                zaleniumExtraHosts = DEFAULT_DOCKER_EXTRA_HOSTS;
-            }
-            return zaleniumExtraHosts;
         } catch (DockerException | InterruptedException e) {
             logger.log(Level.WARNING, nodeId + " Error while getting Zalenium extra hosts.", e);
             ga.trackException(e);
         }
-        zaleniumExtraHosts = DEFAULT_DOCKER_EXTRA_HOSTS;
+        if (zaleniumExtraHosts == null) {
+            zaleniumExtraHosts = DEFAULT_DOCKER_EXTRA_HOSTS;
+        }
         return zaleniumExtraHosts;
     }
 

--- a/src/test/java/de/zalando/ep/zalenium/util/TestUtils.java
+++ b/src/test/java/de/zalando/ep/zalenium/util/TestUtils.java
@@ -169,6 +169,7 @@ public class TestUtils {
 
         AttachedNetwork attachedNetwork = mock(AttachedNetwork.class);
         NetworkSettings networkSettings = mock(NetworkSettings.class);
+        HostConfig hostConfig = mock(HostConfig.class);
 
         ImageInfo imageInfo = mock(ImageInfo.class);
         ContainerConfig containerConfig = mock(ContainerConfig.class);
@@ -184,7 +185,8 @@ public class TestUtils {
         when(networkSettings.networks()).thenReturn(ImmutableMap.of(networkName, attachedNetwork));
         when(networkSettings.ipAddress()).thenReturn("");
         when(containerInfo.networkSettings()).thenReturn(networkSettings);
-
+        when(hostConfig.extraHosts()).thenReturn(null);
+        when(containerInfo.hostConfig()).thenReturn(hostConfig);
 
         String containerId = RandomStringUtils.randomAlphabetic(30).toLowerCase();
         Container container_40000 = mock(Container.class);


### PR DESCRIPTION
Add feature to reflect the extraHost setting of the hub container to node containers. (Discussed in the issue https://github.com/zalando/zalenium/issues/182)

- code changes are only for DockerContainerClient.java, not consider the case of using kubernetes
- logic to read extraHosts from the hub is based on the [existing getZaleniumNetwork](https://github.com/zalando/zalenium/blob/master/src/main/java/de/zalando/ep/zalenium/container/DockerContainerClient.java#L311-L331)