### PR TITLE
Creating service for OpenShift

### DIFF
--- a/docs/k8s/kubernetes.md
+++ b/docs/k8s/kubernetes.md
@@ -170,8 +170,13 @@ oc run zalenium --image=dosel/zalenium \
     --env="ZALENIUM_KUBERNETES_CPU_LIMIT=500m" \
     --env="ZALENIUM_KUBERNETES_MEMORY_REQUEST=1Gi" \
     --overrides='{"spec": {"template": {"spec": {"serviceAccount": "zalenium"}}}}' \
-    -l app=zalenium --port=4444 -- \
+    -l app=zalenium,role=hub --port=4444 -- \
     start --firefoxContainers 0 --chromeContainers 2 --seleniumImageName [registry ip address]:5000/[kubernetes namespace]/selenium:latest
+```
+
+Create the service
+```sh
+oc create -f ./zalenium-service.yaml
 ```
 
 In the Openshift console you should then probably create a route

--- a/docs/k8s/zalenium-service.yaml
+++ b/docs/k8s/zalenium-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: zalenium
+  name: zalenium
+spec:
+  ports:
+  - name: 4444-tcp
+    port: 4444
+    protocol: TCP
+    targetPort: 4444
+  - name: 4445-tcp
+    port: 4445
+    protocol: TCP
+    targetPort: 4445
+  selector:
+    app: zalenium
+    role: hub
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}


### PR DESCRIPTION
Needed to add role=hub to the OpenShift directions, and give a service which specifically selects pods of this role.

I struggled with the directions as written, because the OpenShift directions did not specify a role  the same way the Kubernetes directions did. This was causing the service to bind not only to the zalenium pod, but also to the selenium pods once they spun up.  This caused OpenShift networking to inappropriately direct traffic that was supposed to go to the hub to the nodes.

I also included a zalenium-service.yml which would create the service which properly selects only the zalenium pod.