### PR TITLE
Fixing issue 228

### DIFF
--- a/scripts/zalenium.sh
+++ b/scripts/zalenium.sh
@@ -95,7 +95,7 @@ WaitSauceLabsProxy()
     DONE_MSG="ondemand.saucelabs.com"
     # Using the ZALENIUM_CONTAINER_NAME environment variable here because this method is exported and does not
     # see the variables declared at the beginning
-    while ! docker logs ${ZALENIUM_CONTAINER_NAME} | grep "${DONE_MSG}" >/dev/null; do
+    while ! docker logs ${ZALENIUM_CONTAINER_NAME} 2>&1 | grep "${DONE_MSG}" >/dev/null; do
         echo -n '.'
         sleep 0.2
     done
@@ -115,7 +115,7 @@ WaitBrowserStackProxy()
     DONE_MSG="hub-cloud.browserstack.com"
     # Using the ZALENIUM_CONTAINER_NAME environment variable here because this method is exported and does not
     # see the variables declared at the beginning
-    while ! docker logs ${ZALENIUM_CONTAINER_NAME} | grep "${DONE_MSG}" >/dev/null; do
+    while ! docker logs ${ZALENIUM_CONTAINER_NAME} 2>&1 | grep "${DONE_MSG}" >/dev/null; do
         echo -n '.'
         sleep 0.2
     done
@@ -135,7 +135,7 @@ WaitTestingBotProxy()
     DONE_MSG="hub.testingbot.com"
     # Using the ZALENIUM_CONTAINER_NAME environment variable here because this method is exported and does not
     # see the variables declared at the beginning
-    while ! docker logs ${ZALENIUM_CONTAINER_NAME} | grep "${DONE_MSG}" >/dev/null; do
+    while ! docker logs ${ZALENIUM_CONTAINER_NAME} 2>&1 | grep "${DONE_MSG}" >/dev/null; do
         echo -n '.'
         sleep 0.2
     done


### PR DESCRIPTION
Grepping the `docker logs` command requires some precaution as it is not working as expected. As described in https://stackoverflow.com/questions/34724980/finding-a-string-in-docker-logs-of-container

Instead of grepping, it spits out the whole log, what explains the symptoms described in issue 228. While it looks like an endless loop, in reality no processes were restarted, just the while loop in question was failing to execute the grep, and spitting out the logs over and over again. This ended after 40 seconds as per the timeout logic.

This behavior only happened in detached mode - as highlighted in issue 228 - and some explanation to that can be found in this issue https://github.com/moby/moby/issues/7440, in essence docker logs behaves differently when the `-t` flag is used.

The fix is tested for SauceLabs and Browserstack too, both in `-it` and `-d`.

Hope this explains the situation, otherwise please ask for clarification.
