### PR TITLE
Fixing issue #296 

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/container/DockerContainerClient.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/DockerContainerClient.java
@@ -266,8 +266,9 @@ public class DockerContainerClient implements ContainerClient {
     private void loadMountedFolders(String zaleniumContainerName) {
         if (!this.mntFoldersAndHttpEnvVarsChecked.get()) {
             String containerId = getContainerId(zaleniumContainerName);
-            if (containerId == null)
+            if (containerId == null) {
                 return;
+            }
 
             ContainerInfo containerInfo = null;
 
@@ -282,19 +283,23 @@ public class DockerContainerClient implements ContainerClient {
         }
     }
 
-  private void loadMountedFolders(ContainerInfo containerInfo) {
+  private synchronized void loadMountedFolders(ContainerInfo containerInfo) {
     if (!this.mntFoldersAndHttpEnvVarsChecked.getAndSet(true)) {
 
-      for (ContainerMount containerMount : containerInfo.mounts())
-          if (containerMount.destination().startsWith(NODE_MOUNT_POINT))
+      for (ContainerMount containerMount : containerInfo.mounts()) {
+          if (containerMount.destination().startsWith(NODE_MOUNT_POINT)) {
               this.mntFolders.add(containerMount);
+          }
+      }
 
-      for (String envVar : containerInfo.config().env())
+      for (String envVar : containerInfo.config().env()) {
           Arrays.asList(HTTP_PROXY_ENV_VARS).forEach(httpEnvVar -> {
               String httpEnvVarToAdd = envVar.replace("zalenium_", "");
-              if (envVar.contains(httpEnvVar) && !zaleniumHttpEnvVars.contains(httpEnvVarToAdd))
+              if (envVar.contains(httpEnvVar) && !zaleniumHttpEnvVars.contains(httpEnvVarToAdd)) {
                   zaleniumHttpEnvVars.add(httpEnvVarToAdd);
+              }
           });
+      }
     }
   }
 

--- a/src/test/java/de/zalando/ep/zalenium/container/DockerContainerClientTest.java
+++ b/src/test/java/de/zalando/ep/zalenium/container/DockerContainerClientTest.java
@@ -1,11 +1,7 @@
 package de.zalando.ep.zalenium.container;
 
-import com.spotify.docker.client.DefaultDockerClient;
-import com.spotify.docker.client.DockerClient;
-import com.spotify.docker.client.messages.ContainerConfig;
 import de.zalando.ep.zalenium.util.DockerContainerMock;
 import java.util.HashMap;
-import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
@@ -13,34 +9,14 @@ import org.testng.annotations.Test;
 
 public class DockerContainerClientTest {
 
-  private DockerClient dockerClient;
-  private String zaleniumContainerId;
   private DockerContainerClient containerClient;
 
   @BeforeTest
   public void prepare() throws Exception {
-    dockerClient = new DefaultDockerClient("unix:///var/run/docker.sock");
-    dockerClient.pull("dosel/zalenium:latest");
-    dockerClient.pull("elgalu/selenium:latest");
-
-    ContainerConfig containerConfig =
-        ContainerConfig
-            .builder()
-            .image("dosel/zalenium")
-            .build();
-
-    zaleniumContainerId = dockerClient.createContainer(containerConfig, "zalenium").id();
-
     containerClient =
         DockerContainerMock.getMockedDockerContainerClient();
   }
 
-  @AfterTest
-  public void cleanUp() throws Exception {
-    dockerClient.removeContainer(zaleniumContainerId);
-    dockerClient.removeImage("dosel/zalenium:latest");
-    dockerClient.removeImage("elgalu/selenium:latest");
-  }
 
   @Test(threadPoolSize = 999, invocationCount = 999, timeOut = 10000)
   @Parameters()

--- a/src/test/java/de/zalando/ep/zalenium/container/DockerContainerClientTest.java
+++ b/src/test/java/de/zalando/ep/zalenium/container/DockerContainerClientTest.java
@@ -1,0 +1,57 @@
+package de.zalando.ep.zalenium.container;
+
+import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.messages.ContainerConfig;
+import de.zalando.ep.zalenium.util.DockerContainerMock;
+import java.util.HashMap;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+
+public class DockerContainerClientTest {
+
+  private DockerClient dockerClient;
+  private String zaleniumContainerId;
+  private DockerContainerClient containerClient;
+
+  @BeforeTest
+  public void prepare() throws Exception {
+    dockerClient = new DefaultDockerClient("unix:///var/run/docker.sock");
+    dockerClient.pull("dosel/zalenium:latest");
+    dockerClient.pull("elgalu/selenium:latest");
+
+    ContainerConfig containerConfig =
+        ContainerConfig
+            .builder()
+            .image("dosel/zalenium")
+            .build();
+
+    zaleniumContainerId = dockerClient.createContainer(containerConfig, "zalenium").id();
+
+    containerClient =
+        DockerContainerMock.getMockedDockerContainerClient();
+  }
+
+  @AfterTest
+  public void cleanUp() throws Exception {
+    dockerClient.removeContainer(zaleniumContainerId);
+    dockerClient.removeImage("dosel/zalenium:latest");
+    dockerClient.removeImage("elgalu/selenium:latest");
+  }
+
+  @Test(threadPoolSize = 999, invocationCount = 999, timeOut = 10000)
+  @Parameters()
+  public void createContainer() throws Exception {
+    HashMap<String, String> envVars = new HashMap<>();
+    envVars.put("NOVNC_PORT", "50000");
+    containerClient
+        .createContainer(
+            "zalenium",
+            "elgalu/selenium",
+            envVars,
+            "40000");
+  }
+}


### PR DESCRIPTION
Creating a test to reproduce issue.
Fixing issue about concurrent modification of the collection.
Main reason in the boolean field `mntFoldersAndHttpEnvVarsChecked`.
The type is replaced by AtomicBoolean.

### Motivation and Context
For fix issue #296 

### How Has This Been Tested?
Test created.
Before test pull images - `dosel/zalenium:latest` and `elgalu/selenium:latest` and create container `zalenium`.
Then start test `DockerContainerClientTest.createContainer`.
After test images `dosel/zalenium:latest` and `elgalu/selenium:latest` removed and container `zalenium` deleted.



### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.