### PR TITLE
Browserstack: Supress errors about file not found when starting

### DIFF
--- a/scripts/wait-browserstack.sh
+++ b/scripts/wait-browserstack.sh
@@ -19,7 +19,7 @@ if [ "${BROWSER_STACK_TUNNEL}" = "true" ]; then
   echo "Waiting for BrowserStack tunnel to start..."
   # Required params
   [ -z "${BROWSER_STACK_LOG_FILE}" ] && die "Required env var BROWSER_STACK_LOG_FILE"
-  while ! grep "${DONE_MSG}" ${BROWSER_STACK_LOG_FILE} >/dev/null; do
+  while ! grep -s "${DONE_MSG}" ${BROWSER_STACK_LOG_FILE} >/dev/null; do
     echo -n '.'
     sleep 0.2;
   done


### PR DESCRIPTION
### Description
When we're waiting for browserstack to start, the log file that is
checked might not exist yet resulting in a "file not found" error.
Adding '-s' to grep supress those errors.
```
......Browser Stack node started!
Starting BrowserStackLocal...
Waiting for BrowserStack tunnel to start...
grep: /home/seluser/logs/browserstack-stdout.log: No such file or directory
.............BrowserStack tunnel started! (wait-browserstack.sh)
TestingBot not enabled...
```

### Motivation and Context
Remove output that can be interpreted that something is wrong.
One concern though is that if the file is missing because of other
problems, this might be hard to debug.

Maybe stderr should be redirected to a file so it can be debugged.
Something like:
```
while ! grep "${DONE_MSG}" ${BROWSER_STACK_LOG_FILE} 2>
grep_errors.log > /dev/null; do
```

### How Has This Been Tested?
Only tested by running:
```
$ grep -s 'example' /a/file/that/dont/exist
$ echo $?
2
$ bash --version
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin17)
Copyright (C) 2007 Free Software F
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
<!--- Provide a general summary of your changes in the Title above -->