### PR TITLE
Update /dashboard location in nginux

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -27,8 +27,8 @@ http {
         location / {
             proxy_pass http://127.0.0.1:4445;
         }
-        location /dashboard {
-            alias   /home/seluser/videos;
+        location /dashboard/ {
+            alias   /home/seluser/videos/;
             include /etc/nginx/mime.types;
             index   dashboard.html index.html;
         }


### PR DESCRIPTION
### Description
Change the nginx config to partly solve #353.
/dashboard will now redirect to the selenium hub page instead.
/dashboard/ will show the zalenium dashboard.

### Motivation and Context
People got redirected to a 404 page when the port mapping wasn't `4444:4444`.

### How Has This Been Tested?
```mvn clean package -DskipTests=true -Pbuild-docker-image```
```
$ docker run --rm -ti --name zalenium -p 4444:4444 \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -v /tmp/videos:/home/seluser/videos \
--privileged zalenium:3.10.0c-SNAPSHOT start
```
```curl localhost/dashboard``` <-- result in selenium hub page
```curl localhost/dashboard/``` <-- result in zalenium dashboard

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->