### PR TITLE
Tuning capability matchers and validations, fixes #457

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/matcher/DockerSeleniumCapabilityMatcher.java
+++ b/src/main/java/de/zalando/ep/zalenium/matcher/DockerSeleniumCapabilityMatcher.java
@@ -42,6 +42,12 @@ public class DockerSeleniumCapabilityMatcher extends DefaultCapabilityMatcher {
         logger.log(Level.FINE, ()-> String.format("Validating %s in node with capabilities %s", requestedCapability,
                 nodeCapability));
 
+        if (!requestedCapability.containsKey(CapabilityType.BROWSER_NAME)) {
+            logger.log(Level.FINE, () -> String.format("%s Capability %s does no contain %s key, a docker-selenium " +
+                    "node cannot be started without it", proxy.getId(), requestedCapability, CapabilityType.BROWSER_NAME));
+            return false;
+        }
+
         // We do this because the starter node does not have the browser versions when Zalenium starts
         if (proxy instanceof DockerSeleniumStarterRemoteProxy) {
             Map<String, Object> requestedCapabilityCopy = copyMap(requestedCapability);

--- a/src/main/java/de/zalando/ep/zalenium/matcher/DockerSeleniumCapabilityMatcher.java
+++ b/src/main/java/de/zalando/ep/zalenium/matcher/DockerSeleniumCapabilityMatcher.java
@@ -43,7 +43,7 @@ public class DockerSeleniumCapabilityMatcher extends DefaultCapabilityMatcher {
                 nodeCapability));
 
         if (!requestedCapability.containsKey(CapabilityType.BROWSER_NAME)) {
-            logger.log(Level.FINE, () -> String.format("%s Capability %s does no contain %s key, a docker-selenium " +
+            logger.log(Level.FINE, () -> String.format("%s Capability %s does not contain %s key, a docker-selenium " +
                     "node cannot be started without it", proxy.getId(), requestedCapability, CapabilityType.BROWSER_NAME));
             return false;
         }

--- a/src/main/java/de/zalando/ep/zalenium/matcher/ZaleniumCapabilityMatcher.java
+++ b/src/main/java/de/zalando/ep/zalenium/matcher/ZaleniumCapabilityMatcher.java
@@ -4,7 +4,6 @@ import de.zalando.ep.zalenium.proxy.DockerSeleniumStarterRemoteProxy;
 import org.openqa.grid.internal.RemoteProxy;
 import org.openqa.grid.internal.utils.DefaultCapabilityMatcher;
 import org.openqa.grid.selenium.proxy.DefaultRemoteProxy;
-import org.openqa.selenium.remote.CapabilityType;
 
 import java.util.Map;
 import java.util.logging.Level;
@@ -31,12 +30,6 @@ public class ZaleniumCapabilityMatcher extends DefaultCapabilityMatcher {
         logger.log(Level.FINE, ()-> String.format("Validating %s in node with capabilities %s", requestedCapability,
                 nodeCapability));
 
-        if (!requestedCapability.containsKey(CapabilityType.BROWSER_NAME)) {
-            logger.log(Level.WARNING, () -> String.format("Capability %s does no contain %s key.", requestedCapability,
-                    CapabilityType.BROWSER_NAME));
-            return false;
-        }
-
         for (RemoteProxy remoteProxy : proxy.getRegistry().getAllProxies()) {
             if ((remoteProxy instanceof DockerSeleniumStarterRemoteProxy) &&
                     remoteProxy.hasCapability(requestedCapability)) {
@@ -45,7 +38,6 @@ public class ZaleniumCapabilityMatcher extends DefaultCapabilityMatcher {
                 return false;
             }
         }
-
         return true;
     }
 

--- a/src/main/java/de/zalando/ep/zalenium/proxy/DockerSeleniumRemoteProxy.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/DockerSeleniumRemoteProxy.java
@@ -154,6 +154,12 @@ public class DockerSeleniumRemoteProxy extends DefaultRemoteProxy {
             return null;
         }
 
+        if (!requestedCapability.containsKey(CapabilityType.BROWSER_NAME)) {
+            LOGGER.log(Level.FINE, () -> String.format("%s Capability %s does no contain %s key, a browser test cannot " +
+                            "start without it.", getId(), requestedCapability, CapabilityType.BROWSER_NAME));
+            return null;
+        }
+
         if (!this.isBusy() && increaseCounter()) {
             TestSession newSession = super.getNewSession(requestedCapability);
             LOGGER.log(Level.FINE, getId() + " Creating session for: " + requestedCapability.toString());

--- a/src/main/java/de/zalando/ep/zalenium/proxy/DockerSeleniumRemoteProxy.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/DockerSeleniumRemoteProxy.java
@@ -155,7 +155,7 @@ public class DockerSeleniumRemoteProxy extends DefaultRemoteProxy {
         }
 
         if (!requestedCapability.containsKey(CapabilityType.BROWSER_NAME)) {
-            LOGGER.log(Level.FINE, () -> String.format("%s Capability %s does no contain %s key, a browser test cannot " +
+            LOGGER.log(Level.FINE, () -> String.format("%s Capability %s does not contain %s key, a browser test cannot " +
                             "start without it.", getId(), requestedCapability, CapabilityType.BROWSER_NAME));
             return null;
         }

--- a/src/main/java/de/zalando/ep/zalenium/proxy/DockerSeleniumStarterRemoteProxy.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/DockerSeleniumStarterRemoteProxy.java
@@ -324,8 +324,8 @@ public class DockerSeleniumStarterRemoteProxy extends DefaultRemoteProxy impleme
         }
 
         if (!requestedCapability.containsKey(CapabilityType.BROWSER_NAME)) {
-            LOGGER.log(Level.INFO, () -> String.format("%s Capability %s does no contain %s key.", LOGGING_PREFIX,
-                    requestedCapability, CapabilityType.BROWSER_NAME));
+            LOGGER.log(Level.FINE, () -> String.format("%s Capability %s does no contain %s key, a docker-selenium " +
+                    "node cannot be started without it", LOGGING_PREFIX, requestedCapability, CapabilityType.BROWSER_NAME));
             return null;
         }
 

--- a/src/main/java/de/zalando/ep/zalenium/proxy/DockerSeleniumStarterRemoteProxy.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/DockerSeleniumStarterRemoteProxy.java
@@ -324,7 +324,7 @@ public class DockerSeleniumStarterRemoteProxy extends DefaultRemoteProxy impleme
         }
 
         if (!requestedCapability.containsKey(CapabilityType.BROWSER_NAME)) {
-            LOGGER.log(Level.FINE, () -> String.format("%s Capability %s does no contain %s key, a docker-selenium " +
+            LOGGER.log(Level.FINE, () -> String.format("%s Capability %s does not contain %s key, a docker-selenium " +
                     "node cannot be started without it", LOGGING_PREFIX, requestedCapability, CapabilityType.BROWSER_NAME));
             return null;
         }

--- a/src/test/java/de/zalando/ep/zalenium/proxy/SauceLabsRemoteProxyTest.java
+++ b/src/test/java/de/zalando/ep/zalenium/proxy/SauceLabsRemoteProxyTest.java
@@ -100,17 +100,6 @@ public class SauceLabsRemoteProxyTest {
     }
 
     @Test
-    public void missingBrowserCapabilityDoesNotCreateSession() {
-        // Non existent capability that should not create a session
-        Map<String, Object> nonSupportedCapability = new HashMap<>();
-        nonSupportedCapability.put(CapabilityType.PLATFORM_NAME, Platform.EL_CAPITAN);
-
-        TestSession testSession = sauceLabsProxy.getNewSession(nonSupportedCapability);
-
-        Assert.assertNull(testSession);
-    }
-
-    @Test
     public void sessionIsCreatedWithCapabilitiesThatDockerSeleniumCannotProcess() {
         // Capability which should result in a created session
         Map<String, Object> requestedCapability = new HashMap<>();


### PR DESCRIPTION
Allows to forward tests in mobile devices to the cloud providers.