### PR TITLE
Improve logging with mdc

### DIFF
--- a/docs/_posts/2000-01-05-docker.md
+++ b/docs/_posts/2000-01-05-docker.md
@@ -477,6 +477,11 @@ you can explicitly tell Zalenium which version you are using via `-e DOCKER=17.0
       <td>Output logs in json format</td>
     </tr>
     <tr>
+      <td><code>--logbackConfigFilePath</code></td>
+      <td>logback.xml</td>
+      <td>Path to a custom logback config file.</td>
+    </tr>
+    <tr>
       <td><code>--seleniumImageName</code></td>
       <td>"elgalu/selenium"</td>
       <td>Enables overriding of the Docker selenium image to use.</td>

--- a/scripts/zalenium.sh
+++ b/scripts/zalenium.sh
@@ -21,6 +21,7 @@ START_TUNNEL=${START_TUNNEL:-false}
 DEBUG_ENABLED=${DEBUG_ENABLED:-false}
 KEEP_ONLY_FAILED_TESTS=${KEEP_ONLY_FAILED_TESTS:-false}
 LOG_JSON=${LOG_JSON:-false}
+LOGBACK_PATH=${LOGBACK_PATH:-logback.xml}
 NEW_SESSION_WAIT_TIMEOUT=${NEW_SESSION_WAIT_TIMEOUT:-300000}
 
 GA_TRACKING_ID="UA-88441352-3"
@@ -428,6 +429,7 @@ StartUp()
 
     java ${ZALENIUM_EXTRA_JVM_PARAMS} -Dlogback.loglevel=${DEBUG_MODE} \
     -Dlogback.appender=${LOGBACK_APPENDER} \
+    -Dlogback.configurationFile=${LOGBACK_PATH} \
     -Djava.util.logging.config.file=logging_${DEBUG_MODE}.properties \
     -cp ${ZALENIUM_ARTIFACT} org.openqa.grid.selenium.GridLauncherV3 \
     -role hub -port 4445 -newSessionWaitTimeout ${NEW_SESSION_WAIT_TIMEOUT} \
@@ -454,6 +456,7 @@ StartUp()
 
     java -Dlogback.loglevel=${DEBUG_MODE} -Dlogback.appender=${LOGBACK_APPENDER} \
      -Djava.util.logging.config.file=logging_${DEBUG_MODE}.properties \
+     -Dlogback.configurationFile=${LOGBACK_PATH} \
      -cp ${ZALENIUM_ARTIFACT} org.openqa.grid.selenium.GridLauncherV3 -role node -hub http://localhost:4444/grid/register \
      -registerCycle 0 -proxy de.zalando.ep.zalenium.proxy.DockerSeleniumStarterRemoteProxy \
      -nodePolling 90000 -port 30000 ${DEBUG_FLAG} &
@@ -479,6 +482,7 @@ StartUp()
     if [ "$SAUCE_LABS_ENABLED" = true ]; then
         echo "Starting Sauce Labs node..."
         java -Dlogback.loglevel=${DEBUG_MODE} -Dlogback.appender=${LOGBACK_APPENDER} \
+         -Dlogback.configurationFile=${LOGBACK_PATH} \
          -Djava.util.logging.config.file=logging_${DEBUG_MODE}.properties \
          -cp ${ZALENIUM_ARTIFACT} org.openqa.grid.selenium.GridLauncherV3 -role node -hub http://localhost:4444/grid/register \
          -registerCycle 0 -proxy de.zalando.ep.zalenium.proxy.SauceLabsRemoteProxy \
@@ -507,6 +511,7 @@ StartUp()
     if [ "$BROWSER_STACK_ENABLED" = true ]; then
         echo "Starting Browser Stack node..."
         java -Dlogback.loglevel=${DEBUG_MODE} -Dlogback.appender=${LOGBACK_APPENDER} \
+         -Dlogback.configurationFile=${LOGBACK_PATH} \
          -Djava.util.logging.config.file=logging_${DEBUG_MODE}.properties \
          -cp ${ZALENIUM_ARTIFACT} org.openqa.grid.selenium.GridLauncherV3 -role node -hub http://localhost:4444/grid/register \
          -registerCycle 0 -proxy de.zalando.ep.zalenium.proxy.BrowserStackRemoteProxy \
@@ -534,6 +539,7 @@ StartUp()
     if [ "$TESTINGBOT_ENABLED" = true ]; then
         echo "Starting TestingBot node..."
         java -Dlogback.loglevel=${DEBUG_MODE} -Dlogback.appender=${LOGBACK_APPENDER} \
+         -Dlogback.configurationFile=${LOGBACK_PATH} \
          -Djava.util.logging.config.file=logging_${DEBUG_MODE}.properties \
          -cp ${ZALENIUM_ARTIFACT} org.openqa.grid.selenium.GridLauncherV3 -role node -hub http://localhost:4444/grid/register \
          -registerCycle 0 -proxy de.zalando.ep.zalenium.proxy.TestingBotRemoteProxy \

--- a/scripts/zalenium.sh
+++ b/scripts/zalenium.sh
@@ -780,6 +780,7 @@ function usage()
     echo -e "\t --sendAnonymousUsageInfo -> Collects anonymous usage of the tool. Defaults to 'true'"
     echo -e "\t --debugEnabled -> enables LogLevel.FINE. Defaults to 'false'"
     echo -e "\t --logJson -> output logs in json format. Defaults to 'false'"
+    echo -e "\t --logbackConfigFilePath -> path to a custom logback config file. Defaults to 'logback.xml'"
     echo -e "\t --seleniumImageName -> enables overriding of the Docker selenium image to use. Defaults to \"elgalu/selenium\""
     echo -e "\t --gridUser -> allows you to specify a user to enable basic auth protection, --gridPassword must be provided also."
     echo -e "\t --gridPassword -> allows you to specify a password to enable basic auth protection, --gridUser must be provided also."
@@ -861,6 +862,9 @@ case ${SCRIPT_ACTION} in
                     ;;
                 --logJson)
                     LOG_JSON=${VALUE}
+                    ;;
+                --logbackConfigFilePath)
+                    LOGBACK_PATH=${VALUE}
                     ;;
                 --seleniumImageName)
                     SELENIUM_IMAGE_NAME=${VALUE}

--- a/src/main/java/de/zalando/ep/zalenium/proxy/CloudTestingRemoteProxy.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/CloudTestingRemoteProxy.java
@@ -42,6 +42,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 @SuppressWarnings("WeakerAccess")
 @ManagedService(description = "CloudTesting TestSlots")
@@ -134,8 +135,8 @@ public class CloudTestingRemoteProxy extends DefaultRemoteProxy {
         if (!hasCapability(requestedCapability)) {
             return null;
         }
+
         logger.info("Test will be forwarded to " + getProxyName() + ", " + requestedCapability);
-        logger.info("Currently using " + getNumberOfSessions() + " paralell sessions towards " + getProxyName() + ". Attempt to start one more.");
         return super.getNewSession(requestedCapability);
     }
 
@@ -144,6 +145,11 @@ public class CloudTestingRemoteProxy extends DefaultRemoteProxy {
         if (request instanceof WebDriverRequest && "POST".equalsIgnoreCase(request.getMethod())) {
             WebDriverRequest seleniumRequest = (WebDriverRequest) request;
             if (seleniumRequest.getRequestType().equals(RequestType.START_SESSION)) {
+                int numberOfParallelCloudSessions = getNumberOfSessions();
+                MDC.put("numberOfParallelCloudSessions",String.valueOf(numberOfParallelCloudSessions));
+                logger.info("Currently using " + numberOfParallelCloudSessions + " parallel sessions towards " + getProxyName() + ". Attempt to start one more.");
+                MDC.clear();
+
                 String body = seleniumRequest.getBody();
                 JsonObject jsonObject = new JsonParser().parse(body).getAsJsonObject();
                 JsonObject desiredCapabilities = jsonObject.getAsJsonObject("desiredCapabilities");


### PR DESCRIPTION
### Description
Use MDC to enrich logging. 
- Add desired capabilities as MDC fields when a request is added to queue
- Add MDC field numberOfParallelCloudSessions when a new session is created towards a cloud provider
- Option to provide your own logback.xml file

### Motivation and Context
I want a dashboard that tells me how many parallel session we are using towards a cloud provider.
I also want to visualise what browsers that are used during testing.

### How Has This Been Tested?
- Unit test
- Manual testing of browserstack proxy

### Types of changes
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
