### PR TITLE
Fixes problem with selenium version is not printed in UI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,24 @@
                     <showWarnings>true</showWarnings>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestSections>
+                            <manifestSection>
+                                <Name>Build-Info</Name>
+                                <manifestEntries>
+                                    <Selenium-Version>${selenium-server.major-minor.version}.${selenium-server.patch-level.version}</Selenium-Version>
+                                </manifestEntries>
+                            </manifestSection>
+                        </manifestSections>
+                    </archive>
+                </configuration>
+
+            </plugin>
             <!-- Plugin to build the fat jar -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Description
In zalenium version 3.11.0c the selenium main page does not output the selenium version anymore.
The reason for this is the changes that was introduce by new logging functionality (added by me sorry for that). 

### Motivation and Context
We want to know what version of selenium is running.

### How Has This Been Tested?
Ran unit tests
Manual tests

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->