### PR TITLE
remove the wrong url for the live demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,7 @@ started, please join the #zalenium channel on [Slack](https://seleniumhq.herokua
 * Stop it: `docker stop zalenium`
 
 ## Additional features
-* [Dashboard](http://localhost:4444/dashboard), see all the videos and aggregated logs after your tests completed. 
-Check a live demo [here](http://zalenium.bitballoon.com/dashboard)
+* [Dashboard](http://localhost:4444/dashboard), see all the videos and aggregated logs after your tests completed.
   <p align="center">
     <img id="dashboard" width="600" src="docs/img/dashboard.gif" />
   </p>


### PR DESCRIPTION
**Thanks for contributing to Zalenium! Please give us as much information as possible to merge this PR
quickly.**

<!--- Provide a general summary of your changes in the Title above -->

### Description
remove wrong live demo url  

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Because the Live demo url in not existing

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
<!--- Provide a general summary of your changes in the Title above -->