### PR TITLE
Add initial Prometheus Support

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -26,6 +26,8 @@ http {
 
         location / {
             proxy_pass http://127.0.0.1:4445;
+            proxy_set_header Host      $host;
+            proxy_set_header X-Real-IP $remote_addr;
         }
         location /dashboard/ {
             alias   /home/seluser/videos/;
@@ -33,20 +35,12 @@ http {
             index   dashboard.html index.html;
         }
         location /dashboard/cleanup {
-            proxy_pass http://127.0.0.1:4445/grid/admin/DashboardCleanupServlet;
+            proxy_pass http://127.0.0.1:4445/dashboard/cleanup;
             proxy_set_header Host      $host;
             proxy_set_header X-Real-IP $remote_addr;
         }
         location /dashboard/information {
-            proxy_pass http://127.0.0.1:4445/grid/admin/DashboardInformationServlet;
-            proxy_set_header Host      $host;
-            proxy_set_header X-Real-IP $remote_addr;
-        }
-        location /grid/console {
-            proxy_pass http://127.0.0.1:4445/grid/admin/ZaleniumConsoleServlet;
-        }
-        location /grid/admin/live {
-            proxy_pass http://127.0.0.1:4445/grid/admin/LivePreviewServlet;
+            proxy_pass http://127.0.0.1:4445/dashboard/information;
             proxy_set_header Host      $host;
             proxy_set_header X-Real-IP $remote_addr;
         }
@@ -71,7 +65,7 @@ http {
         }
         location /auth {
             internal;
-            proxy_pass http://127.0.0.1:4445/grid/admin/VncAuthenticationServlet;
+            proxy_pass http://127.0.0.1:4445/vnc/auth;
             proxy_pass_request_body off;
             proxy_set_header        Content-Length "";
             proxy_set_header        X-Original-URI $request_uri;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -13,6 +13,10 @@ http {
     server {
         listen 4444;
 
+        # Fix redirects
+        port_in_redirect off;
+        server_name_in_redirect off;
+        
         satisfy any;
         allow 127.0.0.1;
         auth_basic_user_file        /home/seluser/.htpasswd;
@@ -29,7 +33,7 @@ http {
             proxy_set_header Host      $host;
             proxy_set_header X-Real-IP $remote_addr;
         }
-        location /dashboard/ {
+        location /dashboard {
             alias   /home/seluser/videos/;
             include /etc/nginx/mime.types;
             index   dashboard.html index.html;

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,8 @@
     <properties>
         <selenium-server.major-minor.version>3.11</selenium-server.major-minor.version>
         <selenium-server.patch-level.version>0</selenium-server.patch-level.version>
+        <!-- This needs to match what is in the Selenium Server pom file -->
+        <jetty.version>9.4.8.v20171121</jetty.version>
         <docker-client.version>8.11.2</docker-client.version>
         <kubernetes-client.version>3.1.10</kubernetes-client.version>
         <junit.version>4.12</junit.version>
@@ -69,6 +71,9 @@
         <versions-maven-plugin.version>2.5</versions-maven-plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
+        <prometheus.version>0.3.0</prometheus.version>
+        <aspectj.version>1.8.13</aspectj.version>
+        <aspectj-maven-plugin.version>1.11</aspectj-maven-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <threadCountProperty>1</threadCountProperty>
@@ -79,6 +84,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjrt</artifactId>
+            <version>${aspectj.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-server</artifactId>
@@ -143,6 +153,52 @@
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
             <version>${logstash-logback-encoder.version}</version>
+        </dependency>
+        <!-- The prometheus client -->
+        <dependency>
+          <groupId>io.prometheus</groupId>
+          <artifactId>simpleclient</artifactId>
+          <version>${prometheus.version}</version>
+        </dependency>
+        <!-- Prometheus Hotspot JVM metrics -->
+        <dependency>
+          <groupId>io.prometheus</groupId>
+          <artifactId>simpleclient_hotspot</artifactId>
+          <version>${prometheus.version}</version>
+        </dependency>
+        <!-- Prometheus Exporter Servlet -->
+        <dependency>
+          <groupId>io.prometheus</groupId>
+          <artifactId>simpleclient_servlet</artifactId>
+          <version>${prometheus.version}</version>
+        </dependency>
+        <!-- Prometheus Jetty -->
+        <dependency>
+          <groupId>io.prometheus</groupId>
+          <artifactId>simpleclient_jetty</artifactId>
+          <version>${prometheus.version}</version>
+          <exclusions>
+            <exclusion>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>*</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <!-- 
+        This allows us to add prometheus jetty collectors that expect to find jetty classes in their usual place.
+        Selenium has repackaged Jetty, so this makes it available at compile time, before we relocate the classes again.
+         -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <scope>provided</scope>
+            <version>${jetty.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
@@ -282,6 +338,30 @@
                 </configuration>
 
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>aspectj-maven-plugin</artifactId>
+                <version>${aspectj-maven-plugin.version}</version>
+                <configuration>
+                    <showWeaveInfo>true</showWeaveInfo>
+                    <weaveDependencies>
+                        <weaveDependency>
+                            <groupId>org.seleniumhq.selenium</groupId>
+                            <artifactId>selenium-server</artifactId>
+                        </weaveDependency>
+                    </weaveDependencies>
+                    <complianceLevel>1.8</complianceLevel>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- Plugin to build the fat jar -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -307,6 +387,12 @@
                             <artifactSet>
 
                             </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.eclipse.jetty</pattern>
+                                    <shadedPattern>org.seleniumhq.jetty9</shadedPattern>
+                                </relocation>
+                            </relocations>
                         </configuration>
                     </execution>
                 </executions>

--- a/scripts/zalenium.sh
+++ b/scripts/zalenium.sh
@@ -433,12 +433,6 @@ StartUp()
     -Djava.util.logging.config.file=logging_${DEBUG_MODE}.properties \
     -cp ${ZALENIUM_ARTIFACT} org.openqa.grid.selenium.GridLauncherV3 \
     -role hub -port 4445 -newSessionWaitTimeout ${NEW_SESSION_WAIT_TIMEOUT} \
-    -servlet de.zalando.ep.zalenium.servlet.LivePreviewServlet \
-    -servlet de.zalando.ep.zalenium.servlet.ZaleniumConsoleServlet \
-    -servlet de.zalando.ep.zalenium.servlet.ZaleniumResourceServlet \
-    -servlet de.zalando.ep.zalenium.dashboard.DashboardCleanupServlet \
-    -servlet de.zalando.ep.zalenium.dashboard.DashboardInformationServlet \
-    -servlet de.zalando.ep.zalenium.servlet.VncAuthenticationServlet \
     -registry de.zalando.ep.zalenium.registry.ZaleniumRegistry \
     ${SELENIUM_HUB_PARAMS} \
     ${DEBUG_FLAG} &

--- a/src/main/java/de/zalando/ep/zalenium/aspect/HubAspect.aj
+++ b/src/main/java/de/zalando/ep/zalenium/aspect/HubAspect.aj
@@ -1,0 +1,51 @@
+package de.zalando.ep.zalenium.aspect;
+
+
+import java.util.EnumSet;
+
+import javax.servlet.DispatcherType;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.StatisticsHandler;
+import org.openqa.grid.web.Hub;
+import org.seleniumhq.jetty9.servlet.FilterHolder;
+import org.seleniumhq.jetty9.servlet.ServletContextHandler;
+import org.seleniumhq.jetty9.servlet.ServletHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.prometheus.client.exporter.MetricsServlet;
+import io.prometheus.client.filter.MetricsFilter;
+import io.prometheus.client.hotspot.DefaultExports;
+import io.prometheus.client.jetty.JettyStatisticsCollector;
+
+privileged public aspect HubAspect {
+    private static final Logger log = LoggerFactory.getLogger(HubAspect.class.getName());
+
+    pointcut callAddDefaultServlets(ServletContextHandler handler, Hub hub) :
+        call (private void Hub.addDefaultServlets(ServletContextHandler)) && args(handler) && target(hub);
+    
+    before(ServletContextHandler handler, Hub hub) : callAddDefaultServlets(handler, hub) {
+        log.info("Registering custom Zalenium servlets");
+        
+        FilterHolder prometheusMetricsFilter = handler.addFilter(MetricsFilter.class, "/*", EnumSet.allOf(DispatcherType.class));
+        prometheusMetricsFilter.setInitParameter("metric-name", "webapp_metrics_filter");
+        prometheusMetricsFilter.setInitParameter("help", "This is the help for your metrics filter");
+        prometheusMetricsFilter.setInitParameter("buckets", "0.005,0.01,0.025,0.05,0.075,0.1,0.25,0.5,0.75,1,2.5,5,7.5,10");
+        
+        // Enable prometheus metrics at /metrics
+        handler.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
+        
+        // Configure StatisticsHandler.
+        
+        // This crazy casting is to get around the fact that jetty has been repackaged by selenium, at runtime this will work.
+        Server server = (Server)((Object)hub.server);
+        StatisticsHandler stats = new StatisticsHandler();
+        stats.setHandler(server.getHandler());
+        server.setHandler(stats);
+        // Register collector.
+        new JettyStatisticsCollector(stats).register();
+        
+        DefaultExports.initialize();
+    }
+}

--- a/src/main/java/de/zalando/ep/zalenium/aspect/HubAspect.aj
+++ b/src/main/java/de/zalando/ep/zalenium/aspect/HubAspect.aj
@@ -2,6 +2,7 @@ package de.zalando.ep.zalenium.aspect;
 
 
 import java.util.EnumSet;
+import java.util.List;
 
 import javax.servlet.DispatcherType;
 
@@ -9,11 +10,19 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
 import org.openqa.grid.web.Hub;
 import org.seleniumhq.jetty9.servlet.FilterHolder;
+import org.seleniumhq.jetty9.servlet.FilterMapping;
 import org.seleniumhq.jetty9.servlet.ServletContextHandler;
+import org.seleniumhq.jetty9.servlet.ServletHandler;
 import org.seleniumhq.jetty9.servlet.ServletHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.zalando.ep.zalenium.dashboard.DashboardCleanupServlet;
+import de.zalando.ep.zalenium.dashboard.DashboardInformationServlet;
+import de.zalando.ep.zalenium.servlet.LivePreviewServlet;
+import de.zalando.ep.zalenium.servlet.VncAuthenticationServlet;
+import de.zalando.ep.zalenium.servlet.ZaleniumConsoleServlet;
+import de.zalando.ep.zalenium.servlet.ZaleniumResourceServlet;
 import io.prometheus.client.exporter.MetricsServlet;
 import io.prometheus.client.filter.MetricsFilter;
 import io.prometheus.client.hotspot.DefaultExports;
@@ -28,18 +37,29 @@ privileged public aspect HubAspect {
     before(ServletContextHandler handler, Hub hub) : callAddDefaultServlets(handler, hub) {
         log.info("Registering custom Zalenium servlets");
         
-        FilterHolder prometheusMetricsFilter = handler.addFilter(MetricsFilter.class, "/*", EnumSet.allOf(DispatcherType.class));
-        prometheusMetricsFilter.setInitParameter("metric-name", "webapp_metrics_filter");
-        prometheusMetricsFilter.setInitParameter("help", "This is the help for your metrics filter");
-        prometheusMetricsFilter.setInitParameter("buckets", "0.005,0.01,0.025,0.05,0.075,0.1,0.25,0.5,0.75,1,2.5,5,7.5,10");
+        // This crazy casting is to get around the fact that jetty has been repackaged by selenium, at runtime this will work.
+        Server server = (Server)((Object)hub.server);
+        initialisePrometheus(handler, server);
+        
+        registerZaleniumServlets(handler);
+    }
+    
+    protected void initialisePrometheus(ServletContextHandler handler, Server server) {
+        EnumSet<DispatcherType> allDispatchers = EnumSet.allOf(DispatcherType.class);
+        FilterHolder prometheus = handler.addFilter(MetricsFilter.class, "/wd/*", allDispatchers);
+        prometheus.setInitParameter("metric-name", "webapp_metrics_filter");
+        prometheus.setInitParameter("help", "This is the help for your metrics filter");
+        prometheus.setInitParameter("buckets", "0.005,0.01,0.025,0.05,0.075,0.1,0.25,0.5,0.75,1,2.5,5,7.5,10");
+        // We don't want to go past 3 path-components otherwise every selenium session ends up in the metrics.
+        prometheus.setInitParameter("path-components", "3");
+
+        // Add extra mappings
+        addFilterMappings(handler, prometheus.getName(), new String[] {"/grid/*", "/vnc/*", "/dashboard/*"}, allDispatchers);
         
         // Enable prometheus metrics at /metrics
         handler.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
         
         // Configure StatisticsHandler.
-        
-        // This crazy casting is to get around the fact that jetty has been repackaged by selenium, at runtime this will work.
-        Server server = (Server)((Object)hub.server);
         StatisticsHandler stats = new StatisticsHandler();
         stats.setHandler(server.getHandler());
         server.setHandler(stats);
@@ -47,5 +67,23 @@ privileged public aspect HubAspect {
         new JettyStatisticsCollector(stats).register();
         
         DefaultExports.initialize();
+    }
+    
+    protected void addFilterMappings(ServletContextHandler handler, String filterName, String[] pathSpecs, EnumSet<DispatcherType> dispatchers) {
+        FilterMapping m = new FilterMapping();
+        m.setFilterName(filterName);
+        m.setDispatcherTypes(dispatchers);
+        m.setPathSpecs(pathSpecs);
+        handler.getServletHandler().addFilterMapping(m);
+    }
+    
+    protected void registerZaleniumServlets(ServletContextHandler handler) {
+        handler.addServlet(LivePreviewServlet.class, "/grid/admin/live");
+        handler.addServlet(ZaleniumConsoleServlet.class, "/grid/console");
+        // We want resources to be at least 3 levels deep so that the prometheus servlet filter doesn't pick up all the individual resources
+        handler.addServlet(ZaleniumResourceServlet.class, "/grid/console/resources");
+        handler.addServlet(DashboardCleanupServlet.class, "/dashboard/cleanup");
+        handler.addServlet(DashboardInformationServlet.class, "/dashboard/information");
+        handler.addServlet(VncAuthenticationServlet.class, "/vnc/auth");
     }
 }

--- a/src/main/java/de/zalando/ep/zalenium/dashboard/Dashboard.java
+++ b/src/main/java/de/zalando/ep/zalenium/dashboard/Dashboard.java
@@ -148,16 +148,26 @@ public class Dashboard {
         File videosFolder = new File(getLocalVideosPath());
         String[] extensions = new String[] { "mp4", "mkv", "flv" };
         for (File file : FileUtils.listFiles(videosFolder, extensions, true)) {
-            FileUtils.forceDelete(file);
+            deleteIfExists(file);
         }
-        FileUtils.forceDelete(logsFolder);
-        FileUtils.forceDelete(testList);
-        FileUtils.forceDelete(testCountFile);
-        FileUtils.forceDelete(dashboardHtml);
+        deleteIfExists(logsFolder);
+        deleteIfExists(testList);
+        deleteIfExists(testCountFile);
+        deleteIfExists(dashboardHtml);
         String dashboard = FileUtils.readFileToString(new File(getCurrentLocalPath(), DASHBOARD_TEMPLATE_FILE), UTF_8);
         dashboard = dashboard.replace("{testList}", "").
                 replace("{executedTests}", "0");
         FileUtils.writeStringToFile(dashboardHtml, dashboard, UTF_8);
+    }
+    
+    public static void deleteIfExists(File file) {
+        if (file.exists()) {
+            try {
+                FileUtils.forceDelete(file);
+            } catch (IOException e) {
+                LOGGER.error("Failed to delete file: [" + file.toString() + "]", e);
+            }
+        }
     }
 
     @VisibleForTesting


### PR DESCRIPTION
### Description
Add a Prometheus `/metrics` endpoint to allow monitoring of the zalenium server, initially the JVM and Jetty metrics.  In the future, we would add specific zalenium metrics.  This lays down the initial foundation.

To enable Prometheus to work, it needed to be integrated into the Jetty server, so AspectJ has been used to access the necessary classes.

Registration of the zalenium specific servlets has been moved into Aspect, so that we get greater control of the URLs that we can use.

I also fixed a bug where the cleanup servlet would crash if it tried to delete files/directories that didn't exist.

Additionally, the Nginx redirect problem has been fixed.

### Motivation and Context
This allows us to get greater insight into the performance of zalenium and how it uses resources.  Prometheus has become the defacto standard for monitoring kubernetes clusters, so it makes to most sense to use it.

### How Has This Been Tested?
I ran few multi-threaded selenium tests and checked the `/metrics` endpoint. I also tested the existing zalenium servlets to ensure they still operated.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->