### PR TITLE
Teardown re-registered proxies so that their threads are stopped gc'd.

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/proxy/DockerSeleniumRemoteProxy.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/DockerSeleniumRemoteProxy.java
@@ -105,12 +105,12 @@ public class DockerSeleniumRemoteProxy extends DefaultRemoteProxy {
             throw e;
         }
     }
-    
+
     @Override
     public long getLastSessionStart() {
         return super.getLastSessionStart();
     }
-    
+
     public long getLastCommandTime() {
         return lastCommandTime;
     }


### PR DESCRIPTION
Fixes a race condition where a proxy re-registers after it has been asked to stop and then continues to poll itself and attempt to shutdown.