### PR TITLE
Update probe to use container ip. Fixes #584

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/container/kubernetes/KubernetesContainerClient.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/kubernetes/KubernetesContainerClient.java
@@ -559,7 +559,8 @@ public class KubernetesContainerClient implements ContainerClient {
                         // so then we can initiate a registration.
                         .withNewReadinessProbe()
                             .withNewExec()
-                                .addToCommand(new String[] {"/bin/sh", "-c", "curl -s http://localhost:" + config.getNodePort() + "/wd/hub/status | jq .value.ready | grep true"})
+                                .addToCommand(new String[] {"/bin/sh", "-c", "curl -s http://`getent hosts ${HOSTNAME} | awk '{ print $1 }'`:" 
+                                        + config.getNodePort() + "/wd/hub/status | jq .value.ready | grep true"})
                             .endExec()
                             .withInitialDelaySeconds(5)
                             .withFailureThreshold(60)


### PR DESCRIPTION
Selenium 3.12 doesn't seem to bind to localhost anymore, so updating the probe to look up the container ip. 

Fixes #584 