### PR TITLE
Add Zalenium specific Prometheus metrics

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/proxy/SessionRequestFilter.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/SessionRequestFilter.java
@@ -1,22 +1,33 @@
 package de.zalando.ep.zalenium.proxy;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import de.zalando.ep.zalenium.util.ProcessedCapabilities;
+import io.prometheus.client.Collector;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
 
 public class SessionRequestFilter {
 
 	private static final Logger log = Logger.getLogger(SessionRequestFilter.class.getName());
 	
-	private final List<ProcessedCapabilities> processedCapabilitiesList = new ArrayList<>();
+	private final Map<Integer, ProcessedCapabilities> processedCapabilitiesMap = new ConcurrentHashMap<>();
 
+	static final Gauge seleniumTestSessionsWaiting = Gauge.build()
+            .name("selenium_test_sessions_waiting").help("The number of Selenium test sessions that are waiting for a container").register();
+	
+	static final Histogram seleniumTestSessionStartLatency = Histogram.build()
+	        .name("selenium_test_session_start_latency_seconds")
+	        .help("The Selenium test session start time latency in seconds.")
+	        .buckets(0.5,2.5,5,10,15,20,25,30,35,40,50,60)
+	        .register();
+	
     public boolean hasRequestBeenProcessed(Map<String, Object> requestedCapability) {
         int requestedCapabilityHashCode = System.identityHashCode(requestedCapability);
-        for (ProcessedCapabilities processedCapability : processedCapabilitiesList) {
+        for (ProcessedCapabilities processedCapability : processedCapabilitiesMap.values()) {
 
         	log.log(Level.FINE, "System.identityHashCode(requestedCapability) -> "
                     + System.identityHashCode(requestedCapability) + ", " + requestedCapability);
@@ -46,7 +57,36 @@ public class SessionRequestFilter {
     public void requestHasBeenProcesssed(Map<String, Object> desiredCapabilities) {
         ProcessedCapabilities processedCapabilities = new ProcessedCapabilities(desiredCapabilities,
                 System.identityHashCode(desiredCapabilities));
-        processedCapabilitiesList.add(processedCapabilities);
+        processedCapabilitiesMap.put(processedCapabilities.getIdentityHashCode(), processedCapabilities);
+        seleniumTestSessionsWaiting.inc();
+    }
+    
+    /**
+     * Notify the Session Request Filter that a Test Session has started for the given desiredCapabilities.
+     * 
+     * @param desiredCapabilities The desiredCapabilities to check
+     * @return true if a desiredCapability had been processed before, false if it was never seen.
+     */
+    public boolean testSessionHasStarted(Map<String, Object> desiredCapabilities) {
+        int desiredCapabilityHashCode = System.identityHashCode(desiredCapabilities);
+        ProcessedCapabilities processedCapability = processedCapabilitiesMap.remove(desiredCapabilityHashCode);
+        boolean isSeenBefore = processedCapability != null;
+        long elapsedTime;
+        
+        if (isSeenBefore) {
+            // Since we've seen this test session before, then we can say it's not waiting for a container anymore.
+            seleniumTestSessionsWaiting.dec();
+
+            // Calculate how long the test session request was waiting.
+            elapsedTime = System.currentTimeMillis() - processedCapability.getFirstProcessedTime();
+        }
+        else {
+            // Since we don't actually know how long the request has been around, lets just say it's 100
+            elapsedTime = 100;
+        }
+        
+        seleniumTestSessionStartLatency.observe(elapsedTime / Collector.MILLISECONDS_PER_SECOND);
+        return isSeenBefore;
     }
     
     public void cleanProcessedCapabilities() {
@@ -55,15 +95,13 @@ public class SessionRequestFilter {
             identityHashCode after the garbage collector did its job.
             Not a silver bullet solution, but should be good enough.
          */
-        List<ProcessedCapabilities> processedCapabilitiesToRemove = new ArrayList<>();
-        for (ProcessedCapabilities processedCapability : processedCapabilitiesList) {
-            long timeSinceLastProcess = System.currentTimeMillis() - processedCapability.getLastProcessedTime();
+        processedCapabilitiesMap.entrySet().stream().filter( cap -> {
+            long timeSinceLastProcess = System.currentTimeMillis() - cap.getValue().getLastProcessedTime();
             long maximumLastProcessedTime = 1000 * 60;
-            if (timeSinceLastProcess >= maximumLastProcessedTime) {
-                processedCapabilitiesToRemove.add(processedCapability);
-            }
-        }
-        processedCapabilitiesList.removeAll(processedCapabilitiesToRemove);
+            return timeSinceLastProcess >= maximumLastProcessedTime;
+        })
+        // When you return null on a compute, it deletes the entry from the map
+        .forEach(cap -> processedCapabilitiesMap.compute(cap.getKey(), (hash, capability) -> null));
     }
 	
 }

--- a/src/main/java/de/zalando/ep/zalenium/util/ProcessedCapabilities.java
+++ b/src/main/java/de/zalando/ep/zalenium/util/ProcessedCapabilities.java
@@ -7,11 +7,13 @@ public class ProcessedCapabilities {
     private int identityHashCode;
     private long lastProcessedTime;
     private int processedTimes;
+    private final long firstProcessedTime;
 
     public ProcessedCapabilities(Map<String, Object> requestedCapability, int identityHashCode) {
         this.requestedCapability = requestedCapability;
         this.identityHashCode = identityHashCode;
         this.lastProcessedTime = System.currentTimeMillis();
+        this.firstProcessedTime = this.lastProcessedTime;
         this.processedTimes = 1;
     }
 
@@ -43,4 +45,7 @@ public class ProcessedCapabilities {
         this.processedTimes = processedTimes;
     }
 
+    public long getFirstProcessedTime() {
+        return firstProcessedTime;
+    }
 }


### PR DESCRIPTION
### Description
Add some zalenium specific Prometheus metrics:
* Number of running selenium containers
* Number of starting selenium containers
* Number of test sessions waiting for a container
* Number of test sessions running
* Histogram of Selenium test session start time latency in seconds


### Motivation and Context
These metrics will watch the health of zalenium, and enable tuning of the desiredContainers setting by watching the number of waiting test sessions.  It will also highlight the performance of starting containers.

### How Has This Been Tested?
I've run a bunch of selenium tests by hand and watched the metrics to make sure the increase and decrease as expected.

### Types of changes
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->