### PR TITLE
Fix bug with desired containers counting as waiting test sessions

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/proxy/SessionRequestFilter.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/SessionRequestFilter.java
@@ -6,9 +6,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import de.zalando.ep.zalenium.util.ProcessedCapabilities;
-import io.prometheus.client.Collector;
-import io.prometheus.client.Gauge;
-import io.prometheus.client.Histogram;
 
 public class SessionRequestFilter {
 
@@ -16,41 +13,25 @@ public class SessionRequestFilter {
 	
 	private final Map<Integer, ProcessedCapabilities> processedCapabilitiesMap = new ConcurrentHashMap<>();
 
-	static final Gauge seleniumTestSessionsWaiting = Gauge.build()
-            .name("selenium_test_sessions_waiting").help("The number of Selenium test sessions that are waiting for a container").register();
-	
-	static final Histogram seleniumTestSessionStartLatency = Histogram.build()
-	        .name("selenium_test_session_start_latency_seconds")
-	        .help("The Selenium test session start time latency in seconds.")
-	        .buckets(0.5,2.5,5,10,15,20,25,30,35,40,50,60)
-	        .register();
-	
     public boolean hasRequestBeenProcessed(Map<String, Object> requestedCapability) {
         int requestedCapabilityHashCode = System.identityHashCode(requestedCapability);
-        for (ProcessedCapabilities processedCapability : processedCapabilitiesMap.values()) {
+        ProcessedCapabilities processedCapability = processedCapabilitiesMap.get(requestedCapabilityHashCode);
+        
+        if (processedCapability != null) {
+            processedCapability.setLastProcessedTime(System.currentTimeMillis());
+            int processedTimes = processedCapability.getProcessedTimes() + 1;
+            processedCapability.setProcessedTimes(processedTimes);
 
-        	log.log(Level.FINE, "System.identityHashCode(requestedCapability) -> "
-                    + System.identityHashCode(requestedCapability) + ", " + requestedCapability);
-        	log.log(Level.FINE, "processedCapability.getIdentityHashCode() -> "
-                    + processedCapability.getIdentityHashCode() + ", " + processedCapability.getRequestedCapability());
-
-            if (processedCapability.getIdentityHashCode() == requestedCapabilityHashCode) {
-
-                processedCapability.setLastProcessedTime(System.currentTimeMillis());
-                int processedTimes = processedCapability.getProcessedTimes() + 1;
-                processedCapability.setProcessedTimes(processedTimes);
-
-                if (processedTimes >= 30) {
-                    processedCapability.setProcessedTimes(1);
-                    log.log(Level.INFO, "Request has waited 30 attempts for a node, something " +
-                            "went wrong with the previous attempts, creating a new node for {0}.", requestedCapability);
-                    return false;
-                }
-
-                return true;
+            if (processedTimes >= 30) {
+                processedCapability.setProcessedTimes(1);
+                log.log(Level.INFO, "Request has waited 30 attempts for a node, something " +
+                        "went wrong with the previous attempts, creating a new node for {0}.", requestedCapability);
+                return false;
             }
 
+            return true;
         }
+
         return false;
     }
     
@@ -58,7 +39,6 @@ public class SessionRequestFilter {
         ProcessedCapabilities processedCapabilities = new ProcessedCapabilities(desiredCapabilities,
                 System.identityHashCode(desiredCapabilities));
         processedCapabilitiesMap.put(processedCapabilities.getIdentityHashCode(), processedCapabilities);
-        seleniumTestSessionsWaiting.inc();
     }
     
     /**
@@ -71,21 +51,7 @@ public class SessionRequestFilter {
         int desiredCapabilityHashCode = System.identityHashCode(desiredCapabilities);
         ProcessedCapabilities processedCapability = processedCapabilitiesMap.remove(desiredCapabilityHashCode);
         boolean isSeenBefore = processedCapability != null;
-        long elapsedTime;
-        
-        if (isSeenBefore) {
-            // Since we've seen this test session before, then we can say it's not waiting for a container anymore.
-            seleniumTestSessionsWaiting.dec();
 
-            // Calculate how long the test session request was waiting.
-            elapsedTime = System.currentTimeMillis() - processedCapability.getFirstProcessedTime();
-        }
-        else {
-            // Since we don't actually know how long the request has been around, lets just say it's 100
-            elapsedTime = 100;
-        }
-        
-        seleniumTestSessionStartLatency.observe(elapsedTime / Collector.MILLISECONDS_PER_SECOND);
         return isSeenBefore;
     }
     
@@ -103,5 +69,4 @@ public class SessionRequestFilter {
         // When you return null on a compute, it deletes the entry from the map
         .forEach(cap -> processedCapabilitiesMap.compute(cap.getKey(), (hash, capability) -> null));
     }
-	
 }

--- a/src/main/java/de/zalando/ep/zalenium/util/Environment.java
+++ b/src/main/java/de/zalando/ep/zalenium/util/Environment.java
@@ -62,4 +62,22 @@ public class Environment {
         }
     }
 
+    public double[] getDoubleArrayEnvVariable(String envVariableName, double... defaultValues) {
+        String envVariable = getEnvVariable(envVariableName);
+        double[] buckets;
+        if (envVariable != null) {
+            String[] bucketParams = envVariable.split(",");
+            buckets = new double[bucketParams.length];
+
+            for (int i = 0; i < bucketParams.length; i++) {
+                buckets[i] = Double.parseDouble(bucketParams[i]);
+            }
+
+        }
+        else {
+            buckets = defaultValues;
+        }
+
+        return buckets;
+    }
 }


### PR DESCRIPTION
### Description
Fix bug with desired containers counting as waiting test sessions

* Also make it possible to override bucket size for the test start latency metric.
* Change SessionRequestFilter to use get instead of looping through the map

### How Has This Been Tested?
Manually tested on an OpenShift Cluster, starting concurrent tests with a desiredCapabilities of 2, and ensuring the metric goes back to 0 after no tests are running.

Additionally I changed the bucket size by setting an environment variable of:
`ZALENIUM_TEST_SESSION_LATENCY_BUCKETS=0.5,2.5,5,10,11,12,13,14,15,20,30,60`

I also set `NEW_SESSION_WAIT_TIMEOUT=5000` so that most requests would timeout when waiting for a new container to start, and verified that `selenium_test_sessions_waiting` was decremented for timed out sessions.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
