### PR TITLE
Fix zalenium container search for AWS ECS

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/util/Environment.java
+++ b/src/main/java/de/zalando/ep/zalenium/util/Environment.java
@@ -33,7 +33,7 @@ public class Environment {
     }
 
     public String getStringEnvVariable(String envVariableName, String defaultValue) {
-        if (getEnvVariable(envVariableName) != null) {
+        if (getEnvVariable(envVariableName) != null && !getEnvVariable(envVariableName).isEmpty()) {
             try {
                 return String.valueOf(getEnvVariable(envVariableName));
             } catch (Exception e) {


### PR DESCRIPTION
### Description

When zalenium is used in an AWS container it throws a NullPointerException (issue #463)

### Motivation and Context

In AWS ECS we can't set zalenium's container full name (it's generated with the cluster, task definition, revision, etc), but we can specify a part of it. This means that zalenium can't find it because it searchs  for it by name, in this PR I changed it so that it will search for a container that contains the name provided if the search by full name doesn't return anything.

Besides that I noticed that if a environment variable is set with an empty value (in my case the ones that are used to define the container name) it's assigned as an empty string and that causes the container search to fail too. I believe that it's an error too so I changed the code so that it assigns the default value instead of the empty string.

### How Has This Been Tested?

I built my own image using this branch (it should be updated with the latest master) and checked that zalenium runs. Also all the tests that ran when the image is built passed.

### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] All new and existing tests passed.