### PR TITLE
Replace wdio with webdriverio.

### DIFF
--- a/e2e_test/package-lock.json
+++ b/e2e_test/package-lock.json
@@ -32,17 +32,7 @@
     "ansi-escapes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha1-9zIHu4EgfXX9bIPxJa8m7qN4yjA="
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
     },
     "archiver": {
       "version": "2.1.1",
@@ -55,7 +45,7 @@
         "glob": "7.1.2",
         "lodash": "4.17.10",
         "readable-stream": "2.3.6",
-        "tar-stream": "1.5.2",
+        "tar-stream": "1.6.1",
         "zip-stream": "1.2.0"
       }
     },
@@ -82,15 +72,10 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
-    "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-    },
     "async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
         "lodash": "4.17.10"
       }
@@ -105,15 +90,10 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
       "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
     },
-    "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-    },
     "aws4": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha1-1NDpudv8p3vwjusKikcVUP454ok="
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
     },
     "babel-runtime": {
       "version": "6.26.0",
@@ -130,9 +110,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "optional": true,
       "requires": {
         "tweetnacl": "0.14.5"
@@ -141,7 +121,7 @@
     "bl": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha1-oWCRFxcQPAdBDO9j71Gzl8Alr5w=",
+      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
         "readable-stream": "2.3.6",
         "safe-buffer": "5.1.1"
@@ -164,14 +144,6 @@
         "type-is": "1.6.16"
       }
     },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "requires": {
-        "hoek": "2.16.3"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -187,32 +159,34 @@
       "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
       "dev": true
     },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "requires": {
+        "buffer-alloc-unsafe": "1.1.0",
+        "buffer-fill": "1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
-    },
-    "caseless": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
-    },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
-      }
     },
     "chardet": {
       "version": "0.4.2",
@@ -240,7 +214,7 @@
     "color-convert": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
-      "integrity": "sha1-SYgbj7pn3xKpa98/VsCqueeRMUc=",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
       "requires": {
         "color-name": "1.1.1"
       }
@@ -261,7 +235,8 @@
     "commander": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha1-30boZ9D8Kuxmo0ZitAapzK//Ww8="
+      "integrity": "sha1-30boZ9D8Kuxmo0ZitAapzK//Ww8=",
+      "dev": true
     },
     "compress-commons": {
       "version": "1.2.2",
@@ -323,28 +298,10 @@
         "readable-stream": "2.3.6"
       }
     },
-    "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "requires": {
-        "lru-cache": "4.1.3",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
-      }
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "requires": {
-        "boom": "2.10.1"
-      }
-    },
     "css": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/css/-/css-2.2.3.tgz",
-      "integrity": "sha1-+GH0umHnm+3JYqpUjleA/ZXLxr4=",
+      "integrity": "sha512-0W171WccAjQGGTKLhw4m2nnl0zPHUlTO/I8td4XzJgIB8Hg3ZZx71qT4G4eX8OVsSiaAKiUMy73E3nsbPlg2DQ==",
       "requires": {
         "inherits": "2.0.3",
         "source-map": "0.1.43",
@@ -393,15 +350,10 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
-    "deep-is": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.2.tgz",
-      "integrity": "sha1-nO1l6gvAsJ9CptecGxkD+dkTzBg="
-    },
     "deepmerge": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.0.1.tgz",
-      "integrity": "sha1-JcHCTxEPuRT4AAG5JSZN138/QxI="
+      "integrity": "sha512-VIPwiMJqJ13ZQfaCsIFnp5Me9tnjURiaIFxfz7EH0Ci0dTSQpZtSLrqOicXqEd/z2r+z+Klk9GzmnRsgpgbOsQ=="
     },
     "define-properties": {
       "version": "1.1.2",
@@ -451,7 +403,7 @@
     "ejs": {
       "version": "2.5.9",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.9.tgz",
-      "integrity": "sha1-e6JUWCpWDSZ0NxCaaDVBEkdbDOU="
+      "integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -461,7 +413,7 @@
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
         "once": "1.4.0"
       }
@@ -526,7 +478,7 @@
     "external-editor": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha1-BFURz9jRM/OEZnPRBHwVTiFK09U=",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "requires": {
         "chardet": "0.4.2",
         "iconv-lite": "0.4.19",
@@ -548,18 +500,11 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
-    "fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-      "requires": {
-        "pend": "1.2.0"
-      }
-    },
     "fibers": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fibers/-/fibers-2.0.2.tgz",
-      "integrity": "sha1-Nttj6mHFQxdOImRnX+qMJ4M3E2Y="
+      "integrity": "sha1-Nttj6mHFQxdOImRnX+qMJ4M3E2Y=",
+      "dev": true
     },
     "figures": {
       "version": "2.0.0",
@@ -594,16 +539,6 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
-    "form-data": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
-      }
-    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -613,6 +548,11 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -628,22 +568,9 @@
     "gaze": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-      "integrity": "sha1-xEFzPhO5J6yMD/C0w7Az8ogSkko=",
+      "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
       "requires": {
         "globule": "1.2.1"
-      }
-    },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "requires": {
-        "is-property": "1.0.2"
       }
     },
     "getpass": {
@@ -677,7 +604,7 @@
     "globule": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-      "integrity": "sha1-Xf+xsZHyLSB5epNptJ6rTpg5aW0=",
+      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
       "requires": {
         "glob": "7.1.2",
         "lodash": "4.17.10",
@@ -700,25 +627,6 @@
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
-    "har-validator": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-      "requires": {
-        "chalk": "1.1.3",
-        "commander": "2.15.1",
-        "is-my-json-valid": "2.17.2",
-        "pinkie-promise": "2.0.1"
-      }
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -730,27 +638,11 @@
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
-      }
-    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "http-errors": {
       "version": "1.6.3",
@@ -761,16 +653,6 @@
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
         "statuses": "1.4.0"
-      }
-    },
-    "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
       }
     },
     "iconv-lite": {
@@ -795,7 +677,7 @@
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "requires": {
         "ansi-escapes": "3.1.0",
         "chalk": "2.4.1",
@@ -821,7 +703,7 @@
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
             "color-convert": "1.9.2"
           }
@@ -829,7 +711,7 @@
         "chalk": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
             "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
@@ -847,7 +729,7 @@
         "supports-color": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
             "has-flag": "3.0.0"
           }
@@ -864,55 +746,20 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
-    "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha1-ezUbjo7dTTmV1NBmaA5mTZRpaCQ="
-    },
-    "is-my-json-valid": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-      "integrity": "sha1-ayEDoojpTvPeXPFdKd2F/Et41lw=",
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
-      }
-    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
-    "is2": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/is2/-/is2-0.0.9.tgz",
-      "integrity": "sha1-EZVW0dFlGkG6EFr4AyZ8gLKZ9ik=",
-      "requires": {
-        "deep-is": "0.1.2"
-      }
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isstream": {
       "version": "0.1.2",
@@ -939,11 +786,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -974,16 +816,7 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc="
-    },
-    "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -1021,7 +854,7 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI="
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1030,11 +863,6 @@
       "requires": {
         "brace-expansion": "1.1.11"
       }
-    },
-    "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -6325,38 +6153,15 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
-    "pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "requires": {
-        "pinkie": "2.0.4"
-      }
-    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
-    },
-    "progress": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "proxy-addr": {
       "version": "2.0.3",
@@ -6367,20 +6172,10 @@
         "ipaddr.js": "1.6.0"
       }
     },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-    },
-    "q": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
-      "integrity": "sha1-TeLmyzspCIyeTLwDv51C+5bOL3U="
     },
     "qs": {
       "version": "6.5.1",
@@ -6434,7 +6229,7 @@
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -6455,40 +6250,6 @@
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
-    "request": {
-      "version": "2.79.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-      "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.7.0",
-        "caseless": "0.11.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "2.0.6",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "qs": "6.3.2",
-        "stringstream": "0.0.6",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.4.3",
-        "uuid": "3.2.1"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
-        }
-      }
-    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -6506,7 +6267,7 @@
     "rgb2hex": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.4.tgz",
-      "integrity": "sha1-31RXHVsHodc+d3RH8MjRe0CePqM="
+      "integrity": "sha512-CZAhfcGLXI4DRn+rFsY8zFY5vLJ7oZLYnYeRJjpPFg3eInvFR9El0Ev4/VXzTE0FiQxoyaa9Zl3EnoqXoC5eDw=="
     },
     "run-async": {
       "version": "2.3.0",
@@ -6537,27 +6298,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
-    },
-    "selenium-standalone": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/selenium-standalone/-/selenium-standalone-6.6.0.tgz",
-      "integrity": "sha1-AJc7l5cypU+iZir9i+P7BstgBPE=",
-      "requires": {
-        "async": "2.6.1",
-        "commander": "2.15.1",
-        "cross-spawn": "5.1.0",
-        "debug": "2.6.9",
-        "lodash": "4.17.10",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "progress": "1.1.8",
-        "request": "2.79.0",
-        "tar-stream": "1.5.2",
-        "urijs": "1.19.1",
-        "which": "1.3.1",
-        "yauzl": "2.9.2"
-      }
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "send": {
       "version": "0.16.2",
@@ -6595,31 +6336,10 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY="
     },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "requires": {
-        "shebang-regex": "1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-    },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "requires": {
-        "hoek": "2.16.3"
-      }
     },
     "source-map": {
       "version": "0.1.43",
@@ -6632,7 +6352,7 @@
     "source-map-resolve": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-      "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "requires": {
         "atob": "2.1.1",
         "decode-uri-component": "0.2.0",
@@ -6653,7 +6373,7 @@
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
+        "bcrypt-pbkdf": "1.0.2",
         "dashdash": "1.14.1",
         "ecc-jsbn": "0.1.1",
         "getpass": "0.1.7",
@@ -6677,7 +6397,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
@@ -6701,55 +6421,23 @@
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "5.1.1"
       }
     },
-    "stringstream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha1-eIAiWw1K0Q4wkn0Weh1vL9OzOnI="
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
-    },
-    "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-    },
     "tar-stream": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
-      "integrity": "sha1-+8bG6DwaGdTLSMfZYXH8JI7/x78=",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
+      "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
       "requires": {
         "bl": "1.2.2",
+        "buffer-alloc": "1.2.0",
         "end-of-stream": "1.4.1",
+        "fs-constants": "1.0.0",
         "readable-stream": "2.3.6",
+        "to-buffer": "1.1.1",
         "xtend": "4.0.1"
-      }
-    },
-    "tcp-port-used": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-0.1.2.tgz",
-      "integrity": "sha1-lFDodoyDtBb9TRpqlEnuzL9JbCk=",
-      "requires": {
-        "debug": "0.7.4",
-        "is2": "0.0.9",
-        "q": "0.9.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
-        }
       }
     },
     "through": {
@@ -6760,23 +6448,23 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
         "os-tmpdir": "1.0.2"
       }
     },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+    },
     "tough-cookie": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
         "punycode": "1.4.1"
       }
-    },
-    "tunnel-agent": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -6797,11 +6485,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-    },
-    "urijs": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
-      "integrity": "sha1-Ww/1MMDL3oOG9jQiNbpcpumV0lo="
     },
     "urix": {
       "version": "0.1.0",
@@ -6835,9 +6518,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha1-EsUou51Y0LkmXZovbw/ovhf/HxQ="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "vary": {
       "version": "1.1.2",
@@ -6859,17 +6542,6 @@
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
-      }
-    },
-    "wdio": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/wdio/-/wdio-2.0.2.tgz",
-      "integrity": "sha1-IYv9mM2sN8DyTc8lJ2yxMu+6bec=",
-      "requires": {
-        "fibers": "2.0.2",
-        "selenium-standalone": "6.6.0",
-        "tcp-port-used": "0.1.2",
-        "webdriverio": "4.13.0"
       }
     },
     "wdio-dot-reporter": {
@@ -6900,9 +6572,9 @@
       }
     },
     "webdriverio": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-4.13.0.tgz",
-      "integrity": "sha1-IcIWNgYu0/OOsLCSZ5CDD0DKOQs=",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-4.13.1.tgz",
+      "integrity": "sha1-Yk70ylafPJpejpsRMCtEMe2h+4o=",
       "requires": {
         "archiver": "2.1.1",
         "babel-runtime": "6.26.0",
@@ -6984,7 +6656,7 @@
         "request": {
           "version": "2.87.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-          "integrity": "sha1-MvACNc0I1IK00NaNuTqCnA7VdW4=",
+          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
           "requires": {
             "aws-sign2": "0.7.0",
             "aws4": "1.7.0",
@@ -7005,13 +6677,13 @@
             "safe-buffer": "5.1.1",
             "tough-cookie": "2.3.4",
             "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
+            "uuid": "3.3.2"
           }
         },
         "supports-color": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.0.1.tgz",
-          "integrity": "sha1-HFMx8iJQyEICgFsvF63xZpnzo5o=",
+          "integrity": "sha512-7FQGOlSQ+AQxBNXJpVDj8efTA/FtyB5wcNE1omXXJ0cq6jm1jjDwuROlYDbnzHqdNPqliWFhcioCWSyav+xBnA==",
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -7031,14 +6703,6 @@
       "resolved": "https://registry.npmjs.org/wgxpath/-/wgxpath-1.0.0.tgz",
       "integrity": "sha1-7vikudVYzEla06mit1FZfs2a9pA="
     },
-    "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
-      "requires": {
-        "isexe": "2.0.0"
-      }
-    },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -7053,20 +6717,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
-    "yauzl": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.2.tgz",
-      "integrity": "sha1-T7G8euH8L1cDe1SvasyP4QMcW3c=",
-      "requires": {
-        "buffer-crc32": "0.2.13",
-        "fd-slicer": "1.1.0"
-      }
     },
     "zip-stream": {
       "version": "1.2.0",

--- a/e2e_test/package.json
+++ b/e2e_test/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "express": "^4.16.3",
     "npm": "^6.1.0",
-    "wdio": "^2.0.2"
+    "webdriverio": "^4.13.1"
   },
   "devDependencies": {
     "wdio-dot-reporter": "0.0.9",

--- a/src/main/java/de/zalando/ep/zalenium/proxy/BrowserStackRemoteProxy.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/BrowserStackRemoteProxy.java
@@ -83,38 +83,52 @@ public class BrowserStackRemoteProxy extends CloudTestingRemoteProxy {
         // https://BS_USER:BS_KEY@www.browserstack.com/automate/sessions/SELENIUM_SESSION_ID.json
         String browserStackBaseTestUrl = "https://www.browserstack.com/automate/sessions/";
         String browserStackTestUrl = browserStackBaseTestUrl + String.format("%s.json", seleniumSessionId);
-        JsonObject testData = getCommonProxyUtilities().readJSONFromUrl(browserStackTestUrl, BROWSER_STACK_USER,
-                BROWSER_STACK_KEY).getAsJsonObject();
-        JsonObject automation_session = testData.getAsJsonObject("automation_session");
-        String testName = automation_session.get("name").isJsonNull() ? null : automation_session.get("name").getAsString();
-        String browser = "N/A";
-        if (automation_session.get("browser").isJsonNull()) {
-            if (!automation_session.get("device").isJsonNull()) {
-                browser = automation_session.get("device").getAsString();
+        for (int i = 0; i < 5; i++) {
+            try {
+                JsonObject testData = getCommonProxyUtilities().readJSONFromUrl(browserStackTestUrl, BROWSER_STACK_USER,
+                    BROWSER_STACK_KEY).getAsJsonObject();
+                JsonObject automation_session = testData.getAsJsonObject("automation_session");
+                String testName = automation_session.get("name").isJsonNull() ? null : automation_session.get("name").getAsString();
+                String browser = "N/A";
+                if (automation_session.get("browser").isJsonNull()) {
+                    if (!automation_session.get("device").isJsonNull()) {
+                        browser = automation_session.get("device").getAsString();
+                    }
+                } else {
+                    browser = automation_session.get("browser").getAsString();
+                }
+                String browserVersion = automation_session.get("browser_version").isJsonNull()
+                    ? "N/A" : automation_session.get("browser_version").getAsString();
+                String platform = automation_session.get("os").getAsString();
+                String platformVersion = automation_session.get("os_version").getAsString();
+                String videoUrl = automation_session.get("video_url").getAsString();
+                List<String> logUrls = new ArrayList<>();
+                if (videoUrl.startsWith("http")) {
+                    return new TestInformation.TestInformationBuilder()
+                        .withSeleniumSessionId(seleniumSessionId)
+                        .withTestName(testName)
+                        .withProxyName(getProxyName())
+                        .withBrowser(browser)
+                        .withBrowserVersion(browserVersion)
+                        .withPlatform(platform)
+                        .withTestStatus(TestInformation.TestStatus.COMPLETED)
+                        .withPlatformVersion(platformVersion)
+                        .withFileExtension(getVideoFileExtension())
+                        .withVideoUrl(videoUrl)
+                        .withLogUrls(logUrls)
+                        .withMetadata(getMetadata())
+                        .build();
+                }
+            } catch (Exception e) {
+                logger.debug(e.toString(), e);
+                try {
+                    Thread.sleep(1000 * 10);
+                } catch (InterruptedException ie) {
+                    logger.debug(ie.toString(), ie);
+                }
             }
-        } else {
-            browser = automation_session.get("browser").getAsString();
         }
-        String browserVersion = automation_session.get("browser_version").isJsonNull()
-                ? "N/A" : automation_session.get("browser_version").getAsString();
-        String platform = automation_session.get("os").getAsString();
-        String platformVersion = automation_session.get("os_version").getAsString();
-        String videoUrl = automation_session.get("video_url").getAsString();
-        List<String> logUrls = new ArrayList<>();
-        return new TestInformation.TestInformationBuilder()
-                .withSeleniumSessionId(seleniumSessionId)
-                .withTestName(testName)
-                .withProxyName(getProxyName())
-                .withBrowser(browser)
-                .withBrowserVersion(browserVersion)
-                .withPlatform(platform)
-                .withTestStatus(TestInformation.TestStatus.COMPLETED)
-                .withPlatformVersion(platformVersion)
-                .withFileExtension(getVideoFileExtension())
-                .withVideoUrl(videoUrl)
-                .withLogUrls(logUrls)
-                .withMetadata(getMetadata())
-                .build();
+        return null;
     }
 
     @Override


### PR DESCRIPTION
### Description
This change removes the dependency on a vulnerable version of hoek.
`wdio` was the incorrect package to use, `webdriverio` is the correct one.

### Motivation and Context
Reported vulnerability:
> Known moderate severity security vulnerability detected in hoek < 4.2.1defined in package-lock.json.
> package-lock.json update suggested: hoek ~> 4.2.1.

### How Has This Been Tested?
Ran locally:
```bash
npm test
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project..
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.