### PR TITLE
Change ownership before coping dashboard files

### DIFF
--- a/scripts/zalenium.sh
+++ b/scripts/zalenium.sh
@@ -399,6 +399,7 @@ StartUp()
     fi
 
     echo "Copying files for Dashboard..."
+    sudo chown -R seluser.seluser  /home/seluser/videos
     cp /home/seluser/index.html /home/seluser/videos/index.html
     cp -r /home/seluser/css /home/seluser/videos
     cp -r /home/seluser/js /home/seluser/videos


### PR DESCRIPTION
This will fix permissions issues when coping dashboard files on volume which is automatically created and mounted by k8s.