### PR TITLE
Missing properties added to the values and deployment .yaml files

### DIFF
--- a/docs/k8s/helm/local/zalenium/templates/deployment.yaml
+++ b/docs/k8s/helm/local/zalenium/templates/deployment.yaml
@@ -90,6 +90,8 @@ spec:
             - '{{ .Values.hub.browserStackEnabled }}'
             - '--testingBotEnabled'
             - '{{ .Values.hub.testingBotEnabled }}'
+            - '--videoRecordingEnabled'
+            - '{{ .Values.hub.videoRecordingEnabled }}'
             - '--screenWidth'
             - '{{ .Values.hub.screenWidth }}'
             - '--screenHeight'
@@ -98,6 +100,12 @@ spec:
             - '{{ .Values.hub.timeZone }}'
             - '--seleniumImageName'
             - '{{ .Values.hub.seleniumImageName }}'
+            - '--maxTestSessions'
+            - '{{ .Values.hub.maxTestSessions }}'
+            - '--debugEnabled'
+            - '{{ .Values.hub.debugEnabled }}'
+            - '--sendAnonymousUsageInfo'
+            - '{{ .Values.hub.sendAnonymousUsageInfo }}'
           resources:
 {{ toYaml .Values.hub.resources | indent 12 }}
           volumeMounts:

--- a/docs/k8s/helm/local/zalenium/values.yaml
+++ b/docs/k8s/helm/local/zalenium/values.yaml
@@ -25,12 +25,12 @@ hub:
   ## ref: http://www.seleniumhq.org/docs/07_selenium_grid.jsp#node-configuration
   # seOpts:
 
-  ## Defining a JMX port will open the port on the container, however, it 
+  ## Defining a JMX port will open the port on the container, however, it
   ## requires additional javaOpts, ie
   ## javaOpts: >
-  ##   -Dcom.sun.management.jmxremote.port=4000 
-  ##   -Dcom.sun.management.jmxremote.authenticate=false 
-  ##   -Dcom.sun.management.jmxremote.ssl=false 
+  ##   -Dcom.sun.management.jmxremote.port=4000
+  ##   -Dcom.sun.management.jmxremote.authenticate=false
+  ##   -Dcom.sun.management.jmxremote.ssl=false
   ## ref: http://openjdk.java.net/groups/jmx/
   # jmxPort: 4000
 
@@ -76,6 +76,8 @@ hub:
   timeZone: "UTC"
   seleniumImageName: "elgalu/selenium"
   maxTestSessions: 1
+  debugEnabled: false
+  sendAnonymousUsageInfo: true
 
   # Environment variables passed to Zalenium hub.
   sauceUserName: blank


### PR DESCRIPTION
values.yaml is missing given properties:
debugEnabled
sendAnonymousUsageInfo

Given properties from the values file are not reflected in the deployment.yaml file:
videoRecordingEnabled
maxTestSessions
debugEnabled
sendAnonymousUsageInfo

This commit will add all the missing properties to the helm chart template

### Motivation and Context
My motivation is to thank You for Your great job! 

### How Has This Been Tested?
Helm chart was released with given settings.
Settings were verified organoleptic ;)

### Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)


### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.