### PR TITLE
Add proxy support to kubernetes

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/container/DockerContainerClient.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/DockerContainerClient.java
@@ -60,11 +60,7 @@ public class DockerContainerClient implements ContainerClient {
             "/home/seluser/videos",
             "/dev/shm"
     };
-    private static final String[] HTTP_PROXY_ENV_VARS = {
-            "zalenium_http_proxy",
-            "zalenium_https_proxy",
-            "zalenium_no_proxy"
-    };
+
     private static final Environment defaultEnvironment = new Environment();
     private static Environment env = defaultEnvironment;
     /** Number of times to attempt to create a container when the generated name is not unique. */
@@ -441,15 +437,6 @@ public class DockerContainerClient implements ContainerClient {
                 if (containerMount.destination().startsWith(NODE_MOUNT_POINT)) {
                     this.mntFolders.add(containerMount);
                 }
-            }
-
-            for (String envVar : containerInfo.config().env()) {
-                Arrays.asList(HTTP_PROXY_ENV_VARS).forEach(httpEnvVar -> {
-                    String httpEnvVarToAdd = envVar.replace("zalenium_", "");
-                    if (envVar.contains(httpEnvVar) && !zaleniumHttpEnvVars.contains(httpEnvVarToAdd)) {
-                        zaleniumHttpEnvVars.add(httpEnvVarToAdd);
-                    }
-                });
             }
         }
     }

--- a/src/main/java/de/zalando/ep/zalenium/container/kubernetes/KubernetesContainerClient.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/kubernetes/KubernetesContainerClient.java
@@ -559,7 +559,7 @@ public class KubernetesContainerClient implements ContainerClient {
                         // so then we can initiate a registration.
                         .withNewReadinessProbe()
                             .withNewExec()
-                                .addToCommand(new String[] {"/bin/sh", "-c", "curl -s http://`getent hosts ${HOSTNAME} | awk '{ print $1 }'`:" 
+                                .addToCommand(new String[] {"/bin/sh", "-c", "http_proxy=\"\" curl -s http://`getent hosts ${HOSTNAME} | awk '{ print $1 }'`:" 
                                         + config.getNodePort() + "/wd/hub/status | jq .value.ready | grep true"})
                             .endExec()
                             .withInitialDelaySeconds(5)

--- a/src/main/java/de/zalando/ep/zalenium/proxy/DockeredSeleniumStarter.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/DockeredSeleniumStarter.java
@@ -70,7 +70,14 @@ public class DockeredSeleniumStarter {
     private static Dimension configuredScreenSize;
     private static String containerName;
     private static String dockerSeleniumImageName;
+    private static Map<String, String> zaleniumProxyVars = new HashMap<>();
 
+    private static final String[] HTTP_PROXY_ENV_VARS = {
+            "zalenium_http_proxy",
+            "zalenium_https_proxy",
+            "zalenium_no_proxy"
+    };
+    
     /*
      * Reading configuration values from the env variables, if a value was not provided it falls back to defaults.
      */
@@ -94,6 +101,18 @@ public class DockeredSeleniumStarter {
         setSeleniumNodeParameters(seleniumNodeParams);
 
         sendAnonymousUsageInfo = env.getBooleanEnvVariable("ZALENIUM_SEND_ANONYMOUS_USAGE_INFO", false);
+        
+        addProxyVars();
+    }
+    
+    private static void addProxyVars() {
+        Arrays.asList(HTTP_PROXY_ENV_VARS).forEach(httpEnvVar -> {
+            String proxyValue = env.getStringEnvVariable(httpEnvVar, null);
+            String httpEnvVarToAdd = httpEnvVar.replace("zalenium_", "");
+            if (proxyValue != null) {
+                zaleniumProxyVars.put(httpEnvVarToAdd, proxyValue);
+            }
+        });
     }
     
     static {
@@ -277,6 +296,9 @@ public class DockeredSeleniumStarter {
             envVars.put("CHROME", "false");
             envVars.put("FIREFOX", "false");
             envVars.put("SELENIUM_NODE_PARAMS", seleniumNodeParams);
+            
+            // Add the proxy vars
+            envVars.putAll(zaleniumProxyVars);
             return envVars;
     }
 


### PR DESCRIPTION
Adds proxy support to kubernetes and fixes bug with readiness check if a proxy is specified.

Fixes #625 

### Description
Generalised the `zalenium_http_proxy`, `zalenium_https_proxy` and `zalenium_no_proxy` support to work for kubernetes as well as docker.
### Motivation and Context
Fixes #625 

### How Has This Been Tested?
Testing by hand in openshift specifying the zalenium_ proxy vars and verified that they appeared in the selenium pod environment vars as proper proxy vars.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->