### PR TITLE
Ensure `runLocally` test resets environment variable.

### DIFF
--- a/src/test/java/de/zalando/ep/zalenium/registry/ZaleniumRegistryTest.java
+++ b/src/test/java/de/zalando/ep/zalenium/registry/ZaleniumRegistryTest.java
@@ -73,7 +73,7 @@ public class ZaleniumRegistryTest {
 
         try {
             registry.add(p1);
-            
+
             await().pollInterval(Duration.FIVE_HUNDRED_MILLISECONDS).atMost(Duration.TWO_SECONDS).until(() -> registry.getAllProxies().size() == 1);
 
             RequestHandler newSessionRequest = TestUtils.createNewSessionHandler(registry, requestedCapability);
@@ -88,20 +88,5 @@ public class ZaleniumRegistryTest {
         } finally {
             registry.stop();
         }
-    }
-
-    /*
-        Uncomment the two bottom lines to run Zalenium in development mode.
-        Useful for implementing new features or debugging issues.
-     */
-    @Test
-    public void runLocally() {
-        System.setProperty("runningLocally", "true");
-        GridHubConfiguration gridHubConfiguration = new GridHubConfiguration();
-        gridHubConfiguration.registry = ZaleniumRegistry.class.getCanonicalName();
-        gridHubConfiguration.port = 4445;
-        Hub hub = new Hub(gridHubConfiguration);
-        // hub.start();
-        // Thread.sleep(1000 * 60 * 60);
     }
 }

--- a/src/test/java/de/zalando/ep/zalenium/registry/ZaleniumRunningLocallyTest.java
+++ b/src/test/java/de/zalando/ep/zalenium/registry/ZaleniumRunningLocallyTest.java
@@ -1,0 +1,37 @@
+package de.zalando.ep.zalenium.registry;
+
+import de.zalando.ep.zalenium.util.ZaleniumConfiguration;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.After;
+import org.openqa.grid.internal.utils.configuration.GridHubConfiguration;
+import org.openqa.grid.web.Hub;
+
+public class ZaleniumRunningLocallyTest {
+
+    @Before
+    public void setUp() {
+        System.setProperty("runningLocally", "true");
+    }
+
+    /*
+        Uncomment the two bottom lines to run Zalenium in development mode.
+        Useful for implementing new features or debugging issues.
+     */
+    @Test
+    public void runLocally() {
+        GridHubConfiguration gridHubConfiguration = new GridHubConfiguration();
+        gridHubConfiguration.registry = ZaleniumRegistry.class.getCanonicalName();
+        gridHubConfiguration.port = 4445;
+        Hub hub = new Hub(gridHubConfiguration);
+        // hub.start();
+        // Thread.sleep(1000 * 60 * 60);
+    }
+
+    @After
+    public void tearDown() {
+        System.setProperty("runningLocally", "false");
+        ZaleniumConfiguration.readConfigurationFromEnvVariables();
+    }
+}


### PR DESCRIPTION
This PR fixes a bug where tests were running with `ZALENIUM_RUNNING_LOCALLY` set to `true` and causing failures in some environments (CDP).

<!--- Provide a general summary of your changes in the Title above -->

### Description
The reason for this environment variable being set to `true` is that the test `runLocally` in `ZaleniumRegistryTest.java` explicitly sets it but doesn't clear its value after the test.

This PR moves the `runLocally` test to its own file with explicit setting of the environment variable in `setUp` and `tearDown` methods. It also ensures that the environment variable is loaded into Zalenium's configuration correctly after changing it.

### Motivation and Context
Fix failure in CDP.

### How Has This Been Tested?
Ran `mvn clean test` with the code changes in a Vagrant copy of CDP's Build VM.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->