### PR TITLE
Add support for pushing "stable" images to Zalando open source registry.

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -24,7 +24,7 @@ pipeline:
 
   - desc: Build Zalenium image
     cmd: |
-      IMAGE="zalenium:${CDP_BUILD_VERSION}"
+      IMAGE="registry.opensource.zalan.do/tip/zalenium:${CDP_BUILD_VERSION}"
       mvn clean package
       cd target
       docker build -t $IMAGE .
@@ -40,3 +40,9 @@ pipeline:
   - desc: Run E2E test
     cmd: |
       docker-compose -f ./e2e_test/docker-compose.yaml up --abort-on-container-exit --timeout 30
+
+  - desc: Push Zalenium image
+    cmd: |
+      if [ -z "$CDP_PULL_REQUEST_NUMBER" ]; then
+        docker push $IMAGE
+      fi

--- a/e2e_test/docker-compose.yaml
+++ b/e2e_test/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   zalenium:
-    image: "zalenium:${CDP_BUILD_VERSION}"
+    image: "registry.opensource.zalan.do/tip/zalenium:${CDP_BUILD_VERSION}"
     container_name: zalenium
     hostname: zalenium
     tty: true


### PR DESCRIPTION
### Description
This PR pushes those images that have passed the E2E test to Zalando's open source registry.

### Motivation and Context
This is part 1 of a set of changes to allow for specifying 'stable' images in internal projects.

### How Has This Been Tested?
Ran in CDP.

### Types of changes
- [X] New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] All new and existing tests passed.