### PR TITLE
Push Docker-Selenium image to Zalando open source repo.

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -47,3 +47,11 @@ pipeline:
       if [ -z "$CDP_PULL_REQUEST_NUMBER" ]; then
         docker push $IMAGE
       fi
+
+  - desc: Push Docker-Selenium image
+    cmd: |
+      IMAGE="registry.opensource.zalan.do/tip/docker-selenium:${CDP_BUILD_VERSION}"
+      docker tag elgalu/selenium $IMAGE
+      if [ -z "$CDP_PULL_REQUEST_NUMBER" ]; then
+        docker push $IMAGE
+      fi

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -24,7 +24,7 @@ pipeline:
 
   - desc: Build Zalenium image
     cmd: |
-      IMAGE="registry.opensource.zalan.do/tip/zalenium:${CDP_BUILD_VERSION}"
+      IMAGE="registry-write.opensource.zalan.do/tip/zalenium:${CDP_BUILD_VERSION}"
       mvn clean package
       cd target
       docker build -t $IMAGE .
@@ -43,14 +43,14 @@ pipeline:
 
   - desc: Push Zalenium image
     cmd: |
-      IMAGE="registry.opensource.zalan.do/tip/zalenium:${CDP_BUILD_VERSION}"
+      IMAGE="registry-write.opensource.zalan.do/tip/zalenium:${CDP_BUILD_VERSION}"
       if [ -z "$CDP_PULL_REQUEST_NUMBER" ]; then
         docker push $IMAGE
       fi
 
   - desc: Push Docker-Selenium image
     cmd: |
-      IMAGE="registry.opensource.zalan.do/tip/docker-selenium:${CDP_BUILD_VERSION}"
+      IMAGE="registry-write.opensource.zalan.do/tip/docker-selenium:${CDP_BUILD_VERSION}"
       docker tag elgalu/selenium $IMAGE
       if [ -z "$CDP_PULL_REQUEST_NUMBER" ]; then
         docker push $IMAGE

--- a/e2e_test/docker-compose.yaml
+++ b/e2e_test/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   zalenium:
-    image: "registry.opensource.zalan.do/tip/zalenium:${CDP_BUILD_VERSION}"
+    image: "registry-write.opensource.zalan.do/tip/zalenium:${CDP_BUILD_VERSION}"
     container_name: zalenium
     hostname: zalenium
     tty: true


### PR DESCRIPTION
### Description
Push the Docker-Selenium image used when testing Zalenium to Zalando's open source repository.

### Motivation and Context
This enables pulling compatible Docker-Selenium and Zelenium versions using one tag e.g. master-23 from Zalando's open source repository.
The main use case for this will be a modification to the `p` script by adding a `--tag` flag that enables pulling specific 'stable' tagged images from the open source repo.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->