### PR TITLE
fix(helm): Fixed typos, added initContainer, support multiple zalenium

### DIFF
--- a/docs/k8s/helm/local/zalenium/templates/_helpers.tpl
+++ b/docs/k8s/helm/local/zalenium/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "zalenium.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,24 +10,23 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "zalenium.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
-Create a default fully qualified app name, for hub.
+Create chart name and version as used by the chart label.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "hub.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s-hub" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- define "zalenium.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create the name of the service account
 */}}
-{{- define "serviceAccountName" -}}
+{{- define "zalenium.serviceAccount" -}}
 {{- if .Values.serviceAccount.create -}}
     {{ default (include "name" .) .Values.serviceAccount.name }}
 {{- else -}}

--- a/docs/k8s/helm/local/zalenium/templates/deployment.yaml
+++ b/docs/k8s/helm/local/zalenium/templates/deployment.yaml
@@ -1,44 +1,53 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "hub.fullname" . }}
+  name: {{ template "zalenium.fullname" . }}
   labels:
-    app: {{ template "hub.fullname" . }}
+    app: {{ template "zalenium.name" . }}
     role: grid
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "zalenium.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: {{ template "hub.fullname" . }}
+        app: {{ template "zalenium.name" . }}
         role: grid
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        chart: {{ template "zalenium.chart" . }}
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
       annotations:
     spec:
+      initContainers:
+        - name: zalenium-prepare
+          image: dosel/zalenium:latest
+          command: ['sh', '-c', 'sudo chown -R seluser:seluser /home/seluser/videos']
+          volumeMounts:
+            - name: {{ template "zalenium.fullname" . }}-videos
+              mountPath: /home/seluser/videos
       volumes:
-        - name: {{ template "hub.fullname" . }}-videos
+        - name: {{ template "zalenium.fullname" . }}-videos
         {{- if .Values.persistence.enabled }}
-          {{- if not (empty .Values.persistence.video.name) }}
+          {{- if and (.Values.persistence.video.useExisting) (not (empty .Values.persistence.video.name))}}
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.video.name }}
           {{- else }}
           persistentVolumeClaim:
-            claimName: {{ template "hub.fullname" . }}-videos
+            claimName: {{ template "zalenium.fullname" . }}-videos
           {{- end }}
         {{- else }}
           emptyDir: {}
         {{- end }}
-        - name: {{ template "hub.fullname" . }}-data
+        - name: {{ template "zalenium.fullname" . }}-data
         {{- if .Values.persistence.enabled }}
-          {{- if not (empty .Values.persistence.data.name) }}
+          {{- if and (.Values.persistence.data.useExisting) (not (empty .Values.persistence.data.name))}}
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.data.name }}
           {{- else }}
           persistentVolumeClaim:
-            claimName: {{ template "hub.fullname" . }}-data
+            claimName: {{ template "zalenium.fullname" . }}-data
           {{- end }}
         {{- else }}
           emptyDir: {}
@@ -119,8 +128,8 @@ spec:
           resources:
 {{ toYaml .Values.hub.resources | indent 12 }}
           volumeMounts:
-            - name: {{ template "hub.fullname" . }}-videos
+            - name: {{ template "zalenium.fullname" . }}-videos
               mountPath: /home/seluser/videos
-            - name: {{ template "hub.fullname" . }}-data
+            - name: {{ template "zalenium.fullname" . }}-data
               mountPath: /tmp/mounted
-      serviceAccountName: {{ template "serviceAccountName" . }}
+      serviceAccountName: {{ template "zalenium.serviceAccount" . }}

--- a/docs/k8s/helm/local/zalenium/templates/ingress.yaml
+++ b/docs/k8s/helm/local/zalenium/templates/ingress.yaml
@@ -2,10 +2,10 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "name" . }}
+  name: {{ template "zalenium.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "zalenium.name" . }}
+    chart: {{ template "zalenium.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
@@ -23,6 +23,6 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: {{ template "name" . }}
+          serviceName: {{ template "zalenium.fullname" . }}
           servicePort: {{ .Values.hub.port }}
 {{- end -}}

--- a/docs/k8s/helm/local/zalenium/templates/pvc-efs.yaml
+++ b/docs/k8s/helm/local/zalenium/templates/pvc-efs.yaml
@@ -1,12 +1,12 @@
-{{- if and (.Values.persistence.enabled) (not .Values.persistence.useExisting) }}
+{{- if and (.Values.persistence.enabled) (not .Values.persistence.data.useExisting) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name:  "{{- if not (empty .Values.persistence.data.name) }}{{ .Values.persistence.data.name }}{{- else }}{{ template "hub.fullname" . }}{{- end }}-data"
+  name: {{ template "zalenium.fullname" . }}-data"
   labels:
-    app: "{{- if not (empty .Values.persistence.data.name) }}{{ .Values.persistence.data.name }}{{- else }}{{ template "fullname" . }}{{- end }}"
+    app: {{ template "zalenium.name" . }}
     role: grid
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "zalenium.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -22,15 +22,17 @@ spec:
   storageClassName: "{{ .Values.persistence.data.storageClass }}"
 {{- end }}
 {{- end }}
+{{- end }}
 ---
+{{- if and (.Values.persistence.enabled) (not .Values.persistence.video.useExisting) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: "{{- if not (empty .Values.persistence.video.name) }}{{ .Values.persistence.video.name }}{{- else }}{{ template "hub.fullname" . }}{{- end }}-videos"
+  name: {{ template "zalenium.fullname" . }}-videos"
   labels:
-    app: "{{- if not (empty .Values.persistence.video.name) }}{{ .Values.persistence.video.name }}{{- else }}{{ template "fullname" . }}{{- end }}"
+    app: {{ template "zalenium.name" . }}
     role: grid
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "zalenium.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/docs/k8s/helm/local/zalenium/templates/role-binding.yaml
+++ b/docs/k8s/helm/local/zalenium/templates/role-binding.yaml
@@ -2,18 +2,18 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: {{ if .Values.rbac.clusterWideAccess }}"ClusterRoleBinding"{{ else }}"RoleBinding"{{ end }}
 metadata:
-  name: {{ template "name" . }}
+  name: {{ template "zalenium.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "zalenium.name" . }}
+    chart: {{ template "zalenium.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{ if .Values.rbac.clusterWideAccess }}"ClusterRole"{{ else }}"Role"{{ end }}
-  name: {{ template "name" . }}
+  name: {{ template "fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "name" . }}
+  name: {{ template "zalenium.serviceAccount" . }}
   namespace: "{{ .Release.Namespace }}"
 {{- end -}}

--- a/docs/k8s/helm/local/zalenium/templates/role.yaml
+++ b/docs/k8s/helm/local/zalenium/templates/role.yaml
@@ -2,10 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: {{ if .Values.rbac.clusterWideAccess }}"ClusterRole"{{ else }}"Role"{{ end }}
 metadata:
-  name: {{ template "name" . }}
+  name: {{ template "zalenium.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "zalenium.name" . }}
+    chart: {{ template "zalenium.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:

--- a/docs/k8s/helm/local/zalenium/templates/service-account.yaml
+++ b/docs/k8s/helm/local/zalenium/templates/service-account.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "name" . }}
+  name: {{ template "zalenium.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "zalenium.name" . }}
+    chart: {{ template "zalenium.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- end -}}

--- a/docs/k8s/helm/local/zalenium/templates/service.yaml
+++ b/docs/k8s/helm/local/zalenium/templates/service.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "name" . }}
+  name: {{ template "zalenium.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "zalenium.name" . }}
     role: grid
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "zalenium.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.hub.serviceAnnotations }}
@@ -20,5 +20,5 @@ spec:
     port: {{ .Values.hub.port }}
     targetPort: {{ .Values.hub.port }}
   selector:
-    app: {{ template "hub.fullname" . }}
-    role: grid
+    app: {{ template "zalenium.name" . }}
+    release: "{{ .Release.Name }}"


### PR DESCRIPTION
### Description
I've found some more problems with the helm chart:

- Typo in pvc-efs.yaml which lead to not being able to use existing PVC's
- Missing initContainer lead to permission denied see (https://github.com/zalando/zalenium/issues/631#issuecomment-403448420)
- Based on naming it was not possible to deploy multiple releases to a cluster eg. test/prod
- Lables were not consistent

### How Has This Been Tested?
Deployed in our internal Rancher Cluster with existing PVC's and RBAC turned off

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.