### PR TITLE
Fix helm

### DIFF
--- a/docs/k8s/helm/local/zalenium/templates/_helpers.tpl
+++ b/docs/k8s/helm/local/zalenium/templates/_helpers.tpl
@@ -28,7 +28,7 @@ Create the name of the service account
 */}}
 {{- define "zalenium.serviceAccount" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default (include "name" .) .Values.serviceAccount.name }}
+    {{ default (include "zalenium.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}

--- a/docs/k8s/helm/local/zalenium/templates/pvc-efs.yaml
+++ b/docs/k8s/helm/local/zalenium/templates/pvc-efs.yaml
@@ -2,7 +2,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "zalenium.fullname" . }}-data"
+  name: "{{ template "zalenium.fullname" . }}-data"
   labels:
     app: {{ template "zalenium.name" . }}
     role: grid
@@ -28,7 +28,7 @@ spec:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "zalenium.fullname" . }}-videos"
+  name: "{{ template "zalenium.fullname" . }}-videos"
   labels:
     app: {{ template "zalenium.name" . }}
     role: grid


### PR DESCRIPTION
**Thanks for contributing to Zalenium! Please give us as much information as possible to merge this PR
quickly.**

<!--- Provide a general summary of your changes in the Title above -->
This will provide fix for deploying helm chart to kubernetes with RBAC enabled.

### Description
<!--- Describe your changes in detail -->
* Fix persistent volume claim naming (missing \")
* Fix template reference in _helper.tpl

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Current version returns error if **rbac.create=true** is set:
```
$ helm install --name zalenium   --namespace zalenium   --set persistence.enabled=true   --set rbac.create=true   --set serviceAccount.create=true  local/zalenium

Error: render error in "zalenium/templates/role-binding.yaml": template: zalenium/templates/_helpers.tpl:31:16: executing "zalenium.serviceAccount" at <include "name" .>: error calling include: template: no template "name" associated with template "gotpl"
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Fixed version could be deployed without previous errors:
```
$ helm install --name zalenium   --namespace zalenium   --set persistence.enabled=true  --set rbac.create=true   --set serviceAccount.create=true  local/zalenium
...

$ helm status zalenium
LAST DEPLOYED: Mon Aug 20 15:08:29 2018
NAMESPACE: zalenium
STATUS: DEPLOYED

RESOURCES:
==> v1/PersistentVolumeClaim
NAME                      STATUS  VOLUME                                    CAPACITY  ACCESS MODES  STORAGECLASS  AGE
zalenium-zalenium-data    Bound   pvc-21f44fd3-a47a-11e8-aefe-02ff4aaf7bda  80Gi      RWX           aws-efs       51s
zalenium-zalenium-videos  Bound   pvc-21f5df60-a47a-11e8-aefe-02ff4aaf7bda  80Gi      RWX           aws-efs       51s

==> v1/ServiceAccount
NAME               SECRETS  AGE
zalenium-zalenium  1        51s

==> v1beta1/Role
NAME               AGE
zalenium-zalenium  51s

==> v1beta1/RoleBinding
NAME               AGE
zalenium-zalenium  51s

==> v1/Service
NAME               TYPE          CLUSTER-IP      EXTERNAL-IP       PORT(S)         AGE
zalenium-zalenium  LoadBalancer  100.70.175.175  XXXXXXXXX...  4444:30458/TCP  51s

==> v1beta1/Deployment
NAME               DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
zalenium-zalenium  1        1        1           1          51s

==> v1/Pod(related)
NAME                                READY  STATUS   RESTARTS  AGE
zalenium-zalenium-684bf78b79-h7fgt  1/1    Running  0         51s

```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
<!--- Provide a general summary of your changes in the Title above -->