### PR TITLE
Add lb security

### DIFF
--- a/docs/k8s/helm/README.md
+++ b/docs/k8s/helm/README.md
@@ -57,6 +57,7 @@ See Zalenium's [usage examples](https://github.com/zalando/zalenium/blob/master/
 | `hub.localVolumesRoot` | The root directory to store HostPath volumes (e.g. if running in minikube) | `/tmp` |
 | `hub.resources` | The resources for the hub container, defaults to minimum half a cpu and maximum 512 mb RAM | `{"limits":{"cpu":".5", "memory":"512Mi"}}` |
 | `hub.serviceType` | The Service type | `NodePort` |
+| `hub.serviceSourceRanges` | The list of IPs allowed to connect to the service. Important - in command line you have to escape commas, e.g.: `{"10.10.0.0/24\,10.20.0.0/16"}` | `{"0.0.0.0/0"}` |
 | `hub.serviceSessionAffinity` | The session affinity for the hub service| `None` |
 | `hub.desiredContainers` | How many pods to launch at start | 2 |
 | `hub.maxDockerSeleniumContainers` | Maximum number of Selenium containers to run simultaneously | 10 |

--- a/docs/k8s/helm/local/zalenium/templates/service.yaml
+++ b/docs/k8s/helm/local/zalenium/templates/service.yaml
@@ -14,6 +14,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.hub.serviceType | quote }}
+{{- if eq .Values.hub.serviceType "LoadBalancer" }}
+  loadBalancerSourceRanges: {{ .Values.hub.serviceSourceRanges }}
+{{- end }}
   sessionAffinity: {{ .Values.hub.serviceSessionAffinity | quote }}
   ports:
   - name: hub

--- a/docs/k8s/helm/local/zalenium/values.yaml
+++ b/docs/k8s/helm/local/zalenium/values.yaml
@@ -46,6 +46,11 @@ hub:
   ## ref: https://kubernetes.io/docs/user-guide/services/
   serviceType: "NodePort"
 
+  ## If serviceType is LoadBalancer:
+  ##   Add list of IPs allowed to connect to the service
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
+  serviceSourceRanges: ["0.0.0.0/0"]
+
   ## Control where client requests go, to the same pod or round-robin
   ##   Values: ClientIP or None
   ## ref: https://kubernetes.io/docs/user-guide/services/


### PR DESCRIPTION
**Thanks for contributing to Zalenium! Please give us as much information as possible to merge this PR
quickly.**

I would like to add a parameter to control security group for service LoadBalancer in helm chart.

### Description
1. Additional parameter for helm chart is added
2. Default value for parameter is intact with default settings for kubernetes service.

### Motivation and Context
I think it is a bad idea to deploy a service with default security group, because it allows to connect from 0.0.0.0/0 - so, anyone could connect by default. I would like to change it and add possibility to set a list of IPs which are allowed to connect.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Helm chart was deployed with default settings. Security group for LoadBalancer was created with appropriate settings (`0.0.0.0/0`)
2. Helm chart was deployed with `hub.serviceSourceRanges` set to list of 2 IPs. Security group for LoadBalancer was changed to list IPs passed as a parameter.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
<!--- Provide a general summary of your changes in the Title above -->