### PR TITLE
Change prometheus selenium active sessions gauge to custom collector

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/prometheus/TestSessionCollectorExports.java
+++ b/src/main/java/de/zalando/ep/zalenium/prometheus/TestSessionCollectorExports.java
@@ -1,0 +1,43 @@
+package de.zalando.ep.zalenium.prometheus;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.openqa.grid.internal.ProxySet;
+import org.openqa.grid.internal.RemoteProxy;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.GaugeMetricFamily;
+
+public class TestSessionCollectorExports extends Collector {
+
+    private ProxySet proxySet;
+
+    public TestSessionCollectorExports(ProxySet proxySet) {
+        super();
+        this.proxySet = proxySet;
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect() {
+        GaugeMetricFamily testSessionMetric = new GaugeMetricFamily("selenium_test_sessions_running",
+                "The number of Selenium test sessions that are running by proxy type",
+                Collections.singletonList("proxy"));
+
+        Iterable<RemoteProxy> iterable = () -> proxySet.iterator();
+        Map<String, Integer> countByProxies = StreamSupport.stream(iterable.spliterator(), false).collect(
+                Collectors.groupingBy(p -> p.getClass().getSimpleName(), Collectors.summingInt(p -> p.getTotalUsed())));
+        
+        countByProxies.entrySet().stream()
+                .forEach(e -> testSessionMetric.addMetric(Collections.singletonList(e.getKey()), e.getValue()));
+
+        List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+        mfs.add(testSessionMetric);
+        return mfs;
+    }
+
+}

--- a/src/main/java/de/zalando/ep/zalenium/registry/ZaleniumRegistry.java
+++ b/src/main/java/de/zalando/ep/zalenium/registry/ZaleniumRegistry.java
@@ -1,6 +1,7 @@
 package de.zalando.ep.zalenium.registry;
 
 import de.zalando.ep.zalenium.dashboard.Dashboard;
+import de.zalando.ep.zalenium.prometheus.TestSessionCollectorExports;
 import net.jcip.annotations.ThreadSafe;
 
 import org.openqa.grid.internal.ActiveTestSessions;
@@ -99,6 +100,8 @@ public class ZaleniumRegistry extends BaseGridRegistry implements GridRegistry {
 
         proxies = new AutoStartProxySet(false, minContainers, maxContainers, timeToWaitToStart, waitForAvailableNodes, starter, Clock.systemDefaultZone());
         this.matcherThread.setUncaughtExceptionHandler(new UncaughtExceptionHandler());
+        
+        new TestSessionCollectorExports(proxies).register();
     }
 
     /**


### PR DESCRIPTION
* Now shows active test sessions by underlying proxy

Fixes #703 

### Description
Uses a custom prometheus collector to ensure the accuracy of active sessions. Additionally, active sessions are broken down by proxy type, meaning you could see active sessions by cloud proxy as well.
### Motivation and Context
To fix the leaking of active session counts.

### How Has This Been Tested?
Tested by hand.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->