### PR TITLE
Fix prometheus bug where running/starting containers could be wrong

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
                 <configuration>
                     <archive>
                         <manifestSections>

--- a/src/main/java/de/zalando/ep/zalenium/prometheus/ContainerStatusCollectorExports.java
+++ b/src/main/java/de/zalando/ep/zalenium/prometheus/ContainerStatusCollectorExports.java
@@ -1,0 +1,55 @@
+package de.zalando.ep.zalenium.prometheus;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.groupingBy;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import de.zalando.ep.zalenium.container.ContainerCreationStatus;
+import de.zalando.ep.zalenium.proxy.AutoStartProxySet.ContainerStatus;
+import io.prometheus.client.Collector;
+import io.prometheus.client.GaugeMetricFamily;
+
+public class ContainerStatusCollectorExports extends Collector {
+    
+    private enum States {
+        RUNNING,
+        STARTING;
+    }
+
+    private Map<ContainerCreationStatus, ContainerStatus> startedContainers;
+    private static List<States> STATES = Arrays.asList(States.values());
+
+    public ContainerStatusCollectorExports(Map<ContainerCreationStatus, ContainerStatus> startedContainers) {
+        super();
+        this.startedContainers = startedContainers;
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect() {
+        
+        GaugeMetricFamily seleniumContainersStateMetric = new GaugeMetricFamily("selenium_containers",
+                "The number of Selenium Containers broken down by state",
+                singletonList("state"));
+        
+        Map<States, Long> containerStates = startedContainers.values().stream()
+                .collect(groupingBy(s -> {
+                    return s.isStarted() ? States.RUNNING : States.STARTING;
+                }, counting()));
+        
+        // Ensure that if a state is empty it is 0 instead of missing.
+        STATES.stream().forEach(s -> 
+            seleniumContainersStateMetric.addMetric(singletonList(s.name().toLowerCase()), 
+                Optional.ofNullable(containerStates.get(s)).orElse(0L)));
+
+        List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+        mfs.add(seleniumContainersStateMetric);
+        return mfs;
+    }
+
+}

--- a/src/main/java/de/zalando/ep/zalenium/registry/ZaleniumRegistry.java
+++ b/src/main/java/de/zalando/ep/zalenium/registry/ZaleniumRegistry.java
@@ -1,6 +1,7 @@
 package de.zalando.ep.zalenium.registry;
 
 import de.zalando.ep.zalenium.dashboard.Dashboard;
+import de.zalando.ep.zalenium.prometheus.ContainerStatusCollectorExports;
 import de.zalando.ep.zalenium.prometheus.TestSessionCollectorExports;
 import net.jcip.annotations.ThreadSafe;
 
@@ -98,10 +99,12 @@ public class ZaleniumRegistry extends BaseGridRegistry implements GridRegistry {
         Dashboard.loadTestInformationFromFile();
         Dashboard.setShutDownHook();
 
-        proxies = new AutoStartProxySet(false, minContainers, maxContainers, timeToWaitToStart, waitForAvailableNodes, starter, Clock.systemDefaultZone());
+        AutoStartProxySet autoStart = new AutoStartProxySet(false, minContainers, maxContainers, timeToWaitToStart, waitForAvailableNodes, starter, Clock.systemDefaultZone());
+        proxies = autoStart;
         this.matcherThread.setUncaughtExceptionHandler(new UncaughtExceptionHandler());
         
         new TestSessionCollectorExports(proxies).register();
+        new ContainerStatusCollectorExports(autoStart.getStartedContainers()).register();
     }
 
     /**

--- a/src/test/java/de/zalando/ep/zalenium/prometheus/ContainerStatusCollectorExportsTest.java
+++ b/src/test/java/de/zalando/ep/zalenium/prometheus/ContainerStatusCollectorExportsTest.java
@@ -1,0 +1,74 @@
+package de.zalando.ep.zalenium.prometheus;
+
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import de.zalando.ep.zalenium.container.ContainerCreationStatus;
+import de.zalando.ep.zalenium.proxy.AutoStartProxySet.ContainerStatus;
+import io.prometheus.client.CollectorRegistry;
+
+public class ContainerStatusCollectorExportsTest {
+
+    @Before
+    @After
+    public void resetPrometheus() {
+        CollectorRegistry.defaultRegistry.clear();
+    }
+    
+    @Test
+    public void testEmptyMapBothValuesZero() {
+        Map<ContainerCreationStatus,ContainerStatus> map = new HashMap<ContainerCreationStatus, ContainerStatus>();
+        new ContainerStatusCollectorExports(map).register(CollectorRegistry.defaultRegistry);
+        
+        Double startingValue = CollectorRegistry.defaultRegistry.getSampleValue("selenium_containers", new String[] {"state"}, new String[] {"starting"});
+        Double runningValue = CollectorRegistry.defaultRegistry.getSampleValue("selenium_containers", new String[] {"state"}, new String[] {"running"});
+        assertThat(startingValue, equalTo(0.0));
+        assertThat(runningValue, equalTo(0.0));
+    }
+    
+    @Test
+    public void testIncrementChanges() {
+        // Given an empty map
+        Map<ContainerCreationStatus,ContainerStatus> map = new HashMap<ContainerCreationStatus, ContainerStatus>();
+        new ContainerStatusCollectorExports(map).register(CollectorRegistry.defaultRegistry);
+                
+        // We get an empty values for both states
+        Double startingValue = CollectorRegistry.defaultRegistry.getSampleValue("selenium_containers", new String[] {"state"}, new String[] {"starting"});
+        Double runningValue = CollectorRegistry.defaultRegistry.getSampleValue("selenium_containers", new String[] {"state"}, new String[] {"running"});
+        assertThat(startingValue, equalTo(0.0));
+        assertThat(runningValue, equalTo(0.0));
+        
+        // After we add 2 starting containers
+        ContainerStatus container1 = new ContainerStatus("123", 0l);
+        ContainerStatus container2 = new ContainerStatus("1234", 0l);
+        
+        map.put(mock(ContainerCreationStatus.class), container1);
+        map.put(mock(ContainerCreationStatus.class), container2);
+        
+        // We expect 2 starting and 0 running
+        startingValue = CollectorRegistry.defaultRegistry.getSampleValue("selenium_containers", new String[] {"state"}, new String[] {"starting"});
+        runningValue = CollectorRegistry.defaultRegistry.getSampleValue("selenium_containers", new String[] {"state"}, new String[] {"running"});
+        assertThat(startingValue, equalTo(2.0));
+        assertThat(runningValue, equalTo(0.0));
+        
+        // Once we add a started time
+        container1.setTimeStarted(Optional.of(0l));
+        container2.setTimeStarted(Optional.of(0l));
+
+        // We expect 0 starting and 2 running
+        startingValue = CollectorRegistry.defaultRegistry.getSampleValue("selenium_containers", new String[] {"state"}, new String[] {"starting"});
+        runningValue = CollectorRegistry.defaultRegistry.getSampleValue("selenium_containers", new String[] {"state"}, new String[] {"running"});
+        assertThat(startingValue, equalTo(0.0));
+        assertThat(runningValue, equalTo(2.0));
+    }
+}


### PR DESCRIPTION
### Description
In some circumstances, the Prometheus metrics `selenium_containers_starting` and `selenium_containers_running` could be inaccurate.  This fix changes the way that the data is collected.
### Motivation and Context
Previously the metric was a normal gauge incremented and decremented, but it seems there were some edge cases that weren't handled.  This fix directly reads the map, which is the source of truth, so if the metric is inaccurate in the future, then that would be an indication of a bug inside the `de.zalando.ep.zalenium.proxy.AutoStartProxySet.AutoStartProxySet` class.

As part of this change these metrics: `selenium_containers_starting` and `selenium_containers_running`.
Have been replaced with:
`selenium_containers{state="running"}` and `selenium_containers{state="starting"}` as this lines up with how metrics are usually organised in Prometheus.

### How Has This Been Tested?
Tested it manually in my local Minishift and started some containers and watched the results of `/metrics`.

Additionally, created a test to cover the Prometheus Collector class.

### Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] All new and existing tests passed.
