### PR TITLE
Remove inline CSS from Dashboard’s ‘ui_blocker’.

### DIFF
--- a/dashboard/css/dashboard.css
+++ b/dashboard/css/dashboard.css
@@ -71,6 +71,7 @@ h6 {
     bottom : 0px;
     overflow-x: hidden;
     overflow-y: hidden;
+    display: none;
 }
 
 .ui_blocker_msg

--- a/dashboard/dashboard_template.html
+++ b/dashboard/dashboard_template.html
@@ -19,7 +19,7 @@
 </head>
 
 <body>
-    <div id="ui_blocker" class="ui_blocker" style="display : none;">
+    <div id="ui_blocker" class="ui_blocker">
       <div class="ui_blocker_msg">
         <div>
           Please wait...


### PR DESCRIPTION
### Description

Inline CSS is no longer allowed by default in Jenkins since its
implementation of the ‘Content-Security-Policy’ header.
This means the modal message ‘Please wait...’ is always displayed when
viewing the Dashboard using Jenkins’ HTML Publisher plugin.
Moved ‘display: none’ to ‘dashboard.css’.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested?

1. Configure Jenkins' CSP to allow JavaScript but disallow inline CSS:

```Groovy
System.setProperty("hudson.model.DirectoryBrowserSupport.CSP", "default-src 'self' 'unsafe-inline'; img-src 'self'; style-src 'self'; child-src 'self'; frame-src 'self';")
```

2. Run a job that will publish Zalenium's dashboard through the HTML Publisher plugin.
3. View the Zalenium dashboard --> Verify modal box is not displayed.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] All new and existing tests passed.