### PR TITLE
Adding basic authentication values in K8s helm chart

### DIFF
--- a/docs/k8s/helm/README.md
+++ b/docs/k8s/helm/README.md
@@ -81,8 +81,11 @@ See Zalenium's [usage examples](https://github.com/zalando/zalenium/blob/master/
 | `hub.sauceAccessKey` | Access key to log into saucelabs | blank |
 | `hub.browserStackUser` | Credentials for browserstack | blank |
 | `hub.browserStackKey` | Credentials for browserstack | blank |
-| `hub.testingBotKey` | Credentials for testingbot | blank | 
-| `hub.testingBotSecret` | Credentials for testingbot | blank | 
+| `hub.testingBotKey` | Credentials for testingbot | blank |
+| `hub.testingBotSecret` | Credentials for testingbot | blank |
+| `hub.basicAuth.enabled` | Enables basic authentication | false |
+| `hub.basicAuth.username` | Username for basic authentication | zalenium |
+| `hub.basicAuth.password` | Credentials for testingbot | password |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/docs/k8s/helm/README.md
+++ b/docs/k8s/helm/README.md
@@ -85,7 +85,7 @@ See Zalenium's [usage examples](https://github.com/zalando/zalenium/blob/master/
 | `hub.testingBotSecret` | Credentials for testingbot | blank |
 | `hub.basicAuth.enabled` | Enables basic authentication | false |
 | `hub.basicAuth.username` | Username for basic authentication | zalenium |
-| `hub.basicAuth.password` | Credentials for testingbot | password |
+| `hub.basicAuth.password` | Password for basic authentication | password |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/docs/k8s/helm/local/zalenium/templates/NOTES.txt
+++ b/docs/k8s/helm/local/zalenium/templates/NOTES.txt
@@ -1,1 +1,16 @@
-Hi.
+###################################################
+#                     Zalenium                    #
+###################################################
+
+Your release is named "{{ .Release.Name }}".
+
+{{- if eq true .Values.hub.basicAuth.enabled }}
+Basic Authentication:
+    Username: {{ .Values.hub.basicAuth.username }}
+    Password: {{ .Values.hub.basicAuth.password }}
+{{- end }}
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get {{ .Release.Name }}

--- a/docs/k8s/helm/local/zalenium/templates/NOTES.txt
+++ b/docs/k8s/helm/local/zalenium/templates/NOTES.txt
@@ -14,3 +14,4 @@ To learn more about the release, try:
 
   $ helm status {{ .Release.Name }}
   $ helm get {{ .Release.Name }}
+

--- a/docs/k8s/helm/local/zalenium/templates/_helpers.tpl
+++ b/docs/k8s/helm/local/zalenium/templates/_helpers.tpl
@@ -33,3 +33,10 @@ Create the name of the service account
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create base64 encoded basic authentication for readiness/liveness probe
+*/}}
+{{- define "basicAuth.b64" -}}
+{{- printf "%s:%s" .Values.hub.basicAuth.username .Values.hub.basicAuth.password | b64enc -}}
+{{- end -}}

--- a/docs/k8s/helm/local/zalenium/templates/deployment.yaml
+++ b/docs/k8s/helm/local/zalenium/templates/deployment.yaml
@@ -63,12 +63,22 @@ spec:
             httpGet:
               path: /grid/console
               port: {{ .Values.hub.port }}
+              {{- if eq true .Values.hub.basicAuth.enabled }}
+              httpHeaders:
+              - name: Authorization
+                value: Basic {{ template "basicAuth.b64" . }}
+              {{- end}}
             initialDelaySeconds: 90
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /grid/console
               port: {{ .Values.hub.port }}
+              {{- if eq true .Values.hub.basicAuth.enabled }}
+              httpHeaders:
+              - name: Authorization
+                value: Basic {{ template "basicAuth.b64" . }}
+              {{- end}}
             timeoutSeconds: {{ .Values.hub.readinessTimeout }}
           env:
             - name: ZALENIUM_KUBERNETES_CPU_REQUEST
@@ -127,6 +137,12 @@ spec:
             - '{{ .Values.hub.keepOnlyFailedTests }}'
             - '--retentionPeriod'
             - '{{ .Values.hub.retentionPeriod }}'
+            {{- if eq true .Values.hub.basicAuth.enabled }}
+            - '--gridUser'
+            - '{{ .Values.hub.basicAuth.username }}'
+            - '--gridPassword'
+            - '{{ .Values.hub.basicAuth.password }}'
+            {{- end }}
           resources:
 {{ toYaml .Values.hub.resources | indent 12 }}
           volumeMounts:

--- a/docs/k8s/helm/local/zalenium/values.yaml
+++ b/docs/k8s/helm/local/zalenium/values.yaml
@@ -76,6 +76,10 @@ hub:
   keepOnlyFailedTests: false
   retentionPeriod: 3
   sendAnonymousUsageInfo: true
+  basicAuth:
+    enabled: false
+    username: "zalenium"
+    password: "password"
 
   # Environment variables passed to Zalenium hub.
   sauceUserName: blank


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves #743 

### Description
<!--- Describe your changes in detail -->
I've added additional functionality into the helm chart which allows the user to specify if they want to use basic authentication and the credentials they want to use.  I've also expanded the information that is provided to the user after a successful helm install because "Hi" just didn't seem as cool.

I've updated the readiness/liveness probe to take into account the usage of basic authentication.  Created a template helper that would create a base64 encoded value of the username and password to be used by the readiness/liveness probe http headers.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I wanted this, because I love being able to deploy Zalenium using helm into my K8s cluster, but wasn't happy that there wasn't an easy way to get basic authentication working.  In today's security climate I think the least we can do is put up a username and password in front of it.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this by helm linting the entire chart then I performed the following test cases:
1. Installed this chart using different user credentials from the defaults
2. Installed this chart using the default user credentials
3. Installed this chart without any basic auth

All test cases passed.  I was able to reach all pages (dashboard, console, etc.)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->