### PR TITLE
Add tolerations field

### DIFF
--- a/docs/k8s/helm/README.md
+++ b/docs/k8s/helm/README.md
@@ -48,6 +48,8 @@ See Zalenium's [usage examples](https://github.com/zalando/zalenium/blob/master/
 | `rbac` | If your cluster has RBAC enabled, you can choose to either have the chart create its own service account or provide one.To have the chart create the service account for you, set rbac.create to true | false |
 | `serviceAccount` | Set serviceAccount.create to true if you want to create an service account for zalenium | false |
 | `ingress` | Set ingress.enabled to true if you want to create an ingress entry for zalenium | false |
+| `nodeSelector` | Configure node selector if you want to run zalenium on specified nodes | false |
+| `tolerations` | Configure tolerations if you want to run zalenium on nodes with taints | false |
 | `hub.image` | The zalenium hub image | `dosel/zalenium` |
 | `hub.tag` | The zalenium hub image tag | `3` |
 | `hub.pullPolicy` | The pull policy for the hub image | `IfNotPresent` |

--- a/docs/k8s/helm/local/zalenium/templates/deployment.yaml
+++ b/docs/k8s/helm/local/zalenium/templates/deployment.yaml
@@ -151,3 +151,14 @@ spec:
             - name: {{ template "zalenium.fullname" . }}-data
               mountPath: /tmp/mounted
       serviceAccountName: {{ template "zalenium.serviceAccount" . }}
+      {{- if .Values.nodeSelector.enabled }}
+      nodeSelector:
+        {{ .Values.nodeSelector.key }}: {{ .Values.nodeSelector.value | quote }}
+      {{- end }}
+      {{- if .Values.tolerations.enabled }}
+      tolerations:
+        - key: {{ .Values.tolerations.key }}
+          operator: {{ .Values.tolerations.operator }}
+          value: {{ .Values.tolerations.value | quote }}
+          effect: {{ .Values.tolerations.effect }}
+      {{- end }}

--- a/docs/k8s/helm/local/zalenium/values.yaml
+++ b/docs/k8s/helm/local/zalenium/values.yaml
@@ -143,3 +143,17 @@ rbac:
   ## Run the zalenium hub container with the ability to deploy/manage containers of jobs
   ## cluster-wide or only within namespace
   clusterWideAccess: false
+
+nodeSelector:
+  enabled: false
+  ## Run zalenium hub on specified nodes
+  ## key: test
+  ## value: test
+
+tolerations:
+  enabled: false
+  ## Set tolerations to run zalenium hub on nodes with taints
+  ## key: test
+  ## operator: Equal
+  ## value: test
+  ## effect: NoSchedule

--- a/src/main/java/de/zalando/ep/zalenium/container/kubernetes/KubernetesContainerClient.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/kubernetes/KubernetesContainerClient.java
@@ -37,6 +37,7 @@ import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
@@ -63,6 +64,7 @@ public class KubernetesContainerClient implements ContainerClient {
     private Map<VolumeMount, Volume> mountedSharedFoldersMap = new HashMap<>();
     private List<HostAlias> hostAliases = new ArrayList<>();
     private Map<String, String> nodeSelector = new HashMap<>();
+    private List<Toleration> tolerations = new ArrayList<>();
 
     private final Map<String, Quantity> seleniumPodLimits = new HashMap<>();
     private final Map<String, Quantity> seleniumPodRequests = new HashMap<>();
@@ -98,6 +100,7 @@ public class KubernetesContainerClient implements ContainerClient {
             discoverFolderMounts();
             discoverHostAliases();
             discoverNodeSelector();
+            discoverTolerations();
 
             buildResourceMaps();
 
@@ -149,6 +152,13 @@ public class KubernetesContainerClient implements ContainerClient {
         final Map<String, String> configuredNodeSelector = zaleniumPod.getSpec().getNodeSelector();
         if (configuredNodeSelector != null && !configuredNodeSelector.isEmpty()) {
             nodeSelector = configuredNodeSelector;
+        }
+    }
+
+    private void discoverTolerations() {
+        final List<Toleration> configuredTolerations = zaleniumPod.getSpec().getTolerations();
+        if (configuredTolerations != null && !configuredTolerations.isEmpty()) {
+            tolerations = configuredTolerations;
         }
     }
 
@@ -322,6 +332,7 @@ public class KubernetesContainerClient implements ContainerClient {
         config.setMountedSharedFoldersMap(mountedSharedFoldersMap);
         config.setHostAliases(hostAliases);
         config.setNodeSelector(nodeSelector);
+        config.setTolerations(tolerations);
         config.setPodLimits(seleniumPodLimits);
         config.setPodRequests(seleniumPodRequests);
 
@@ -535,6 +546,7 @@ public class KubernetesContainerClient implements ContainerClient {
                 .endMetadata()
                 .withNewSpec()
                     .withNodeSelector(config.getNodeSelector())
+                    .withTolerations(config.getTolerations())
                     // Add a memory volume that we can use for /dev/shm
                     .addNewVolume()
                         .withName("dshm")

--- a/src/main/java/de/zalando/ep/zalenium/container/kubernetes/PodConfiguration.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/kubernetes/PodConfiguration.java
@@ -5,6 +5,7 @@ import io.fabric8.kubernetes.api.model.HostAlias;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.client.KubernetesClient;
 
 import java.util.List;
@@ -23,6 +24,7 @@ public class PodConfiguration {
     private Map<String, Quantity> podLimits;
     private Map<String, Quantity> podRequests;
     private Map<String, String> nodeSelector;
+    private List<Toleration> tolerations;
     
     private String nodePort;
 
@@ -91,5 +93,11 @@ public class PodConfiguration {
     }
     public void setNodeSelector(final Map<String, String> nodeSelector) {
         this.nodeSelector = nodeSelector;
+    }
+    public List<Toleration> getTolerations() {
+        return tolerations;
+    }
+    public void setTolerations(final List<Toleration> tolerations) {
+        this.tolerations = tolerations;
     }
 }

--- a/src/test/java/de/zalando/ep/zalenium/container/kubernetes/PodConfigurationTest.java
+++ b/src/test/java/de/zalando/ep/zalenium/container/kubernetes/PodConfigurationTest.java
@@ -1,0 +1,131 @@
+package de.zalando.ep.zalenium.container.kubernetes;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.HostAlias;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.Toleration;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PodConfigurationTest {
+
+    private PodConfiguration podConfiguration;
+
+    @BeforeTest
+    public void prepare() {
+        podConfiguration = new PodConfiguration();
+    }
+
+    @Test
+    public void setNodePort() {
+        podConfiguration.setNodePort("test");
+        assertThat(podConfiguration.getNodePort(), containsString("test"));
+    }
+
+    @Test
+    public void setKubernetesClient() {
+        KubernetesClient client = mock(KubernetesClient.class);
+        podConfiguration.setClient(client);
+        assertThat(podConfiguration.getClient(), is(client));
+    }
+
+    @Test
+    public void setContainerIdPrefix() {
+        podConfiguration.setContainerIdPrefix("test");
+        assertThat(podConfiguration.getContainerIdPrefix(), containsString("test"));
+    }
+
+    @Test
+    public void setImage() {
+        podConfiguration.setImage("test");
+        assertThat(podConfiguration.getImage(), containsString("test"));
+    }
+
+    @Test
+    public void setEnvVars() {
+        EnvVar envVar = mock(EnvVar.class);
+        List<EnvVar> envVars = new ArrayList<>();
+        envVars.add(envVar);
+        podConfiguration.setEnvVars(envVars);
+        assertThat(podConfiguration.getEnvVars().size(), is(1));
+        assertThat(podConfiguration.getEnvVars(), is(envVars));
+    }
+
+    @Test
+    public void setLabels() {
+        Map<String, String> labels = new HashMap<>();
+        labels.put("key", "value");
+        podConfiguration.setLabels(labels);
+        assertThat(podConfiguration.getLabels().get("key"), containsString("value"));
+    }
+
+    @Test
+    public void setPodLimits() {
+        Map<String, Quantity> limits = new HashMap<>();
+        Quantity quantity = mock(Quantity.class);
+        limits.put("key", quantity);
+        podConfiguration.setPodLimits(limits);
+        assertThat(podConfiguration.getPodLimits().get("key"), is(quantity));
+    }
+
+    @Test
+    public void setPodRequests() {
+        Map<String, Quantity> requests = new HashMap<>();
+        Quantity quantity = mock(Quantity.class);
+        requests.put("key", quantity);
+        podConfiguration.setPodRequests(requests);
+        assertThat(podConfiguration.getPodRequests().get("key"), is(quantity));
+    }
+
+    @Test
+    public void setMountedSharedFoldersMap() {
+        Map<VolumeMount, Volume> mountedSharedFoldersMap = new HashMap<>();
+        VolumeMount volumeMount = mock(VolumeMount.class);
+        Volume volume = mock(Volume.class);
+        mountedSharedFoldersMap.put(volumeMount, volume);
+        podConfiguration.setMountedSharedFoldersMap(mountedSharedFoldersMap);
+        assertThat(podConfiguration.getMountedSharedFoldersMap().get(volumeMount), is(volume));
+    }
+
+    @Test
+    public void setHostAliases() {
+        List<HostAlias> hostAliases = new ArrayList<>();
+        HostAlias hostAlias = mock(HostAlias.class);
+        hostAliases.add(hostAlias);
+        podConfiguration.setHostAliases(hostAliases);
+        assertThat(podConfiguration.getHostAliases().size(), is(1));
+        assertThat(podConfiguration.getHostAliases().get(0), is(hostAlias));
+    }
+
+    @Test
+    public void setNodeSelector() {
+        Map<String, String> nodeSelector = new HashMap<>();
+        nodeSelector.put("key", "value");
+        podConfiguration.setNodeSelector(nodeSelector);
+        assertThat(podConfiguration.getNodeSelector().get("key"), containsString("value"));
+    }
+
+    @Test
+    public void setTolerations() {
+        List<Toleration> tolerations = new ArrayList<>();
+        Toleration toleration = mock(Toleration.class);
+        tolerations.add(toleration);
+        podConfiguration.setTolerations(tolerations);
+        assertThat(podConfiguration.getTolerations().size(), is(1));
+        assertThat(podConfiguration.getTolerations().get(0), is(toleration));
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Add toleration field to pod configuration to be able to use zalenium on nodes with taints.

### Motivation and Context
At the moment selenium nodes that are created after start of zalenium always stuck in pending status - they can't start on tainted nodes ([issue](https://github.com/zalando/zalenium/issues/745))

### How Has This Been Tested?
I tested this feature on k8s cluster v1.12.1 with 1 master and 2 nodes.
One of nodes had taints. I deployed zalenium with 2 desired selenium containers and configured tolerations. All works as expected.
After I've removed tolerations I redeployed zalenium and check that without taints and tolerations all works fine.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->