### PR TITLE
Dashboard - pass search text as parameter in the URL

### DIFF
--- a/dashboard/dashboard_template.html
+++ b/dashboard/dashboard_template.html
@@ -214,7 +214,21 @@
     <!-- Taken from https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/js/bootstrap.min.js -->
     <script src="js/bootstrap.min.js"></script>
     <script>
+        $(function() {
+            var url = new URL(window.location);
+            var params = url.searchParams;
+            var q = params.get('q');
+            if (q !== null && q !== '') {
+                $('#search').val(decodeURIComponent(q));
+                searchTestsList();
+            }
+        });
+
         $(document).on('keyup', '#search', function () {
+            searchTestsList();
+        });
+
+        function searchTestsList() {
             var current_query = $('#search').val().toUpperCase();
             if (current_query !== "") {
                 var tokens_crt_query = current_query.split(" ");
@@ -239,7 +253,7 @@
             } else {
                 $(".list-group li").show();
             }
-        });
+        }
 
         $("#tests").on("click", ".list-group-item", function() {
             var $this = $(this);

--- a/docs/_posts/2000-01-07-usage.md
+++ b/docs/_posts/2000-01-07-usage.md
@@ -51,6 +51,10 @@ See more details at `build name`.
 <br>
 <br>    
   * Also reset the dashboard via `http://localhost:4444/dashboard/cleanup?action=doReset` or cleanup via `http://localhost:4444/dashboard/cleanup?action=doCleanup`
+* You can search tests by query parameter `q`
+<br>
+<br>    
+  * E.g. `http://localhost:4444/dashboard/?q=test01`
 
 ***
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Add functionality passing search text as query parameter on dashboard.
This enable to search and filter tests on dashboard by URL parameter e.g. `http://localhost:4444/dashboard/?q=test01`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
implement #284

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Type browser address bar `http://localhost:4444/dashboard/?q=yourTestName`
2. Verify tests are filtered by `yourTestName`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
