### PR TITLE
Fixed permissions for nginx.conf

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -332,7 +332,7 @@ ENV ZAL_VER="${project.build.finalName}" \
     SELENIUM_WAIT_FOR_CONTAINER="true"
 
 COPY entry.sh log warn error /usr/bin/
-COPY nginx.conf /etc/nginx/
+COPY nginx.conf /home/seluser/
 COPY css/ /home/seluser/css/
 COPY js/ /home/seluser/js/
 COPY zalenium.sh \
@@ -369,9 +369,7 @@ RUN sudo chmod +x /home/seluser/zalenium.sh \
   && sudo chmod +x /usr/bin/error \
   && sudo chmod +x /usr/bin/entry.sh \
   && sudo chmod 777 /etc/passwd \
-  && sudo chown -R seluser:seluser /home/seluser \
-  && sudo chown -R root:seluser /etc/nginx \
-  && sudo chmod -R g+w /etc/nginx
+  && sudo chown -R seluser:seluser /home/seluser
 
 # Allows different operations in Openshift environments
 # https://docs.openshift.com/container-platform/latest/creating_images/guidelines.html#openshift-specific-guidelines

--- a/scripts/zalenium.sh
+++ b/scripts/zalenium.sh
@@ -404,10 +404,10 @@ StartUp()
     fi
 
     # In nginx.conf, Replace {{contextPath}} with value of APPEND_CONTEXT_PATH
-    sed -i.bak "s~{{contextPath}}~${CONTEXT_PATH}~" /etc/nginx/nginx.conf
+    sed -i.bak "s~{{contextPath}}~${CONTEXT_PATH}~" /home/seluser/nginx.conf
 
     echo "Starting Nginx reverse proxy..."
-    nginx
+    nginx -c /home/seluser/nginx.conf
 
     echo "Starting Selenium Hub..."
 


### PR DESCRIPTION
Fixed permissions for nginx.conf in openshift

### Description
`nginx.conf` can't be edited by `sed` due to lack of permissions in an openshift. 

### Motivation and Context
I tried to deploy the latest zalenium in an openshift dedicated cluster but the nginx was no able to start. `sed` couldn't replace `contextPath` in `nginx.conf` due to lack of permissions. I put nginx.conf to `/home/seluser` directory and run nginx with `-c` parameter. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I just started zalenium container using docker and ran some my ui tests there. Then I did it the same in our openshift cluster. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->