### PR TITLE
Add support to use imagePullSecret on pod creation

### DIFF
--- a/charts/zalenium/templates/_pod-template.yaml
+++ b/charts/zalenium/templates/_pod-template.yaml
@@ -9,6 +9,10 @@ spec:
     fsGroup: {{ .Values.hub.securityContext.fsGroup }}
     runAsUser: {{ .Values.hub.securityContext.runAsUser }}
   {{- end }}
+  {{- if .Values.hub.pullSecrets }}
+  imagePullSecrets:
+    - name: {{ .Values.hub.imagePullSecret }}
+  {{- end}}
   volumes:
     - name: {{ template "zalenium.fullname" . }}-videos
     {{- if .Values.persistence.video.enabled }}

--- a/charts/zalenium/values.yaml
+++ b/charts/zalenium/values.yaml
@@ -11,6 +11,10 @@ hub:
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   pullPolicy: "IfNotPresent"
 
+  ## Specify secrets to pull images from private repositories
+  ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+  #imagePullSecret: "secret1"
+
   ## The port which the hub listens on
   port: 4444
 

--- a/src/main/java/de/zalando/ep/zalenium/container/kubernetes/PodConfiguration.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/kubernetes/PodConfiguration.java
@@ -2,10 +2,11 @@ package de.zalando.ep.zalenium.container.kubernetes;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HostAlias;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
-import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.client.KubernetesClient;
 
 import java.util.List;
@@ -18,6 +19,7 @@ public class PodConfiguration {
     private String containerIdPrefix;
     private String image;
     private String imagePullPolicy;
+    private List<LocalObjectReference> imagePullSecrets;
     private List<EnvVar> envVars;
     private List<HostAlias> hostAliases;
     private Map<String, String> labels;
@@ -26,12 +28,12 @@ public class PodConfiguration {
     private Map<String, Quantity> podRequests;
     private Map<String, String> nodeSelector;
     private List<Toleration> tolerations;
-
     private String nodePort;
 
     public String getNodePort() {
         return nodePort;
     }
+
     public void setNodePort(String nodePort) {
         this.nodePort = nodePort;
     }
@@ -61,6 +63,12 @@ public class PodConfiguration {
     }
     public List<EnvVar> getEnvVars() {
         return envVars;
+    }
+    public List<LocalObjectReference> getImagePullSecrets() {
+        return imagePullSecrets;
+    }
+    public void setImagePullSecrets(List<LocalObjectReference> imagePullSecrets) {
+        this.imagePullSecrets = imagePullSecrets;
     }
     public void setEnvVars(List<EnvVar> envVars) {
         this.envVars = envVars;

--- a/src/test/java/de/zalando/ep/zalenium/container/kubernetes/PodConfigurationTest.java
+++ b/src/test/java/de/zalando/ep/zalenium/container/kubernetes/PodConfigurationTest.java
@@ -1,25 +1,25 @@
 package de.zalando.ep.zalenium.container.kubernetes;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.mock;
-
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HostAlias;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
-import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class PodConfigurationTest {
 
@@ -127,5 +127,15 @@ public class PodConfigurationTest {
         podConfiguration.setTolerations(tolerations);
         assertThat(podConfiguration.getTolerations().size(), is(1));
         assertThat(podConfiguration.getTolerations().get(0), is(toleration));
+    }
+
+    @Test
+    public void testSetImagePullSecrets() {
+        List<LocalObjectReference> secrets = new ArrayList<>();
+        LocalObjectReference secret = mock(LocalObjectReference.class);
+        secrets.add(secret);
+        podConfiguration.setImagePullSecrets(secrets);
+        assertThat(podConfiguration.getImagePullSecrets().size(), is(1));
+        assertThat(podConfiguration.getImagePullSecrets().get(0), is(secret));
     }
 }


### PR DESCRIPTION
Make it possible to use imagePullSecret to pull zalenium images from private repositories.

Pods created by zalenium will use the same imagePullSecret.