### PR TITLE
adds support for livenessTimeout configuration

### DIFF
--- a/charts/zalenium/README.md
+++ b/charts/zalenium/README.md
@@ -61,6 +61,7 @@ See Zalenium's [usage examples](https://github.com/zalando/zalenium/blob/master/
 | `hub.tag` | The zalenium hub image tag | `3` |
 | `hub.pullPolicy` | The pull policy for the hub image | `IfNotPresent` |
 | `hub.port` | The port the hub listens on | `4444` |
+| `hub.livenessTimeout` | Timeout for probe Hub liveness via HTTP request on Hub console | `1` |
 | `hub.readinessTimeout` | Timeout for probe Hub readiness via HTTP request on Hub console | `1` |
 | `hub.localVolumesRoot` | The root directory to store HostPath volumes (e.g. if running in minikube) | `/tmp` |
 | `hub.resources` | The resources for the hub container, defaults to minimum half a cpu and maximum 512 mb RAM | `{"limits":{"cpu":".5", "memory":"512Mi"}}` |

--- a/charts/zalenium/templates/_pod-template.yaml
+++ b/charts/zalenium/templates/_pod-template.yaml
@@ -56,6 +56,7 @@ spec:
           {{- end}}
         initialDelaySeconds: 90
         periodSeconds: 5
+        timeoutSeconds: {{ .Values.hub.livenessTimeout }}
       readinessProbe:
         httpGet:
           path: {{ if and (.Values.ingress.path) (not (eq .Values.ingress.path "/")) }}{{ .Values.ingress.path }}{{ end }}/grid/console

--- a/charts/zalenium/values.yaml
+++ b/charts/zalenium/values.yaml
@@ -18,6 +18,9 @@ hub:
   ## The port which the hub listens on
   port: 4444
 
+  ## Timeout for probe Hub liveness via HTTP request on Hub console
+  livenessTimeout: 1
+  
   ## Timeout for probe Hub readiness via HTTP request on Hub console
   readinessTimeout: 1
 


### PR DESCRIPTION
### Description

Adds support for hub liveness probe timeout in line with the existing readinessTimeout configuration

### Motivation and Context

When adjusting the readiness probe timeout one will likely want to adjust the liveness probe timeout as well.

### How Has This Been Tested?

Set it to values > 1 and nothing broke.

### Types of changes
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
