### PR TITLE
fix role.yaml

### DIFF
--- a/charts/zalenium/templates/role.yaml
+++ b/charts/zalenium/templates/role.yaml
@@ -14,7 +14,7 @@ rules:
   verbs:
   - create
   - delete
-  - deleteCollection
+  - deletecollection
   - get
   - list
   - watch


### PR DESCRIPTION
### Description
Rename verb deleteCollection to deletecollection according to the [doc](https://kubernetes.io/docs/reference/access-authn-authz/authorization/#determine-the-request-verb)

### Motivation and Context
If a user a non cluster-admin user tries to deploy zalenium in a project, it will fails because `deleteCollection` does not match the permission `deletecollection`.
This is a summary of the issue, the error message just state that it tries to create a role with higher privilege than the user has.

### How Has This Been Tested?
Tested on Openshift v3.10

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->