### PR TITLE
Improve remote debug documentation

### DIFF
--- a/docs/_posts/2000-01-05-docker.md
+++ b/docs/_posts/2000-01-05-docker.md
@@ -437,19 +437,19 @@ you can explicitly tell Zalenium which version you are using via `-e DOCKER=17.0
         You also have to specify the port on remote host to which the debugger should connect. 
         In the following example we are using the <code>port 8000</code>.
         <br>
-        {% highlight shell %}
-            docker run --rm -ti --name zalenium -p 4444:4444 -p 8000:8000\
-              -e ZALENIUM_EXTRA_JVM_PARAMS="-Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y"
-              -v /var/run/docker.sock:/var/run/docker.sock \
-              -v /tmp/videos:/home/seluser/videos \
-              --privileged dosel/zalenium start 
-        {% endhighlight %}
+{% highlight shell %}
+docker run --rm -ti --name zalenium -p 4444:4444 -p 8000:8000\
+  -e ZALENIUM_EXTRA_JVM_PARAMS="-Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=y"
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /tmp/videos:/home/seluser/videos \
+  --privileged dosel/zalenium start
+{% endhighlight %}
         <br>
-        The last key <code>suspend</code> can have two values. The value <code>y</code> means that the apllication will be
+        The last key <code>suspend</code> can have two values. The value <code>y</code> means that the application will be
         suspended until any remote debugger is connected. The value <code>n</code> means that the application will 
         not be suspended for any remote debugging. Use the value <code>y</code> to debug start up logic.
         <br>
-        Don't forget to check if you IDE is able to use remote debugging and is properly configurated. That means setting
+        Don't forget to check if you IDE is able to use remote debugging and is properly configured. That means setting
         the correct host and port in your IDE Debug Configuration.
     </div>
 

--- a/docs/_posts/2000-01-05-docker.md
+++ b/docs/_posts/2000-01-05-docker.md
@@ -445,9 +445,21 @@ docker run --rm -ti --name zalenium -p 4444:4444 -p 8000:8000\
   --privileged dosel/zalenium start
 {% endhighlight %}
         <br>
-        The last key <code>suspend</code> can have two values. The value <code>y</code> means that the application will be
-        suspended until any remote debugger is connected. The value <code>n</code> means that the application will 
-        not be suspended for any remote debugging. Use the value <code>y</code> to debug start up logic.
+        The last key <code>suspend</code> can have two values. The value <code>y</code> means that the application will
+        be suspended until any remote debugger is connected. As the scripts/zalenium.sh script includes a 1 minute
+        timeout for selenium hub to has been started you should increase these timeout when using <code>suspend=y</code>
+        and rebuild your image. In the following example the timeout has been increased to 30 minutes:
+{% highlight shell %}
+if ! timeout --foreground "30m" bash -c WaitSeleniumHub; then
+    echo "GridLauncher failed to start after 1 minute, failing..."
+    curl "http://localhost:4444${CONTEXT_PATH}/wd/hub/status"
+    exit 11
+fi
+echo "Selenium Hub started!"
+{% endhighlight %}
+        Use the value <code>y</code> to debug start up logic.
+        <br>
+        The value <code>n</code> means that the application will not be suspended for any remote debugging.
         <br>
         Don't forget to check if you IDE is able to use remote debugging and is properly configured. That means setting
         the correct host and port in your IDE Debug Configuration.

--- a/scripts/zalenium.sh
+++ b/scripts/zalenium.sh
@@ -441,7 +441,7 @@ StartUp()
 
     echo $! > ${PID_PATH_SELENIUM}
     
-    if ! timeout --foreground "1m" bash -c WaitSeleniumHub; then
+    if ! timeout --foreground "90m" bash -c WaitSeleniumHub; then
         echo "GridLauncher failed to start after 1 minute, failing..."
         curl "http://localhost:4444${CONTEXT_PATH}/wd/hub/status"
         exit 11


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Add information increasing timeout for selenium hub when debugging start up logic.

### Motivation and Context
Trying to debug start up logic would run into timeouts and this information was missing.

### How Has This Been Tested?
No test as it affects only documentation.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
<!--- Provide a general summary of your changes in the Title above -->