### PR TITLE
Use the same network for both hub and nodes.

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/container/DockerContainerClient.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/DockerContainerClient.java
@@ -595,10 +595,11 @@ public class DockerContainerClient implements ContainerClient {
                     "variable ZALENIUM_CONTAINER_NAME has an appropriate value", zaleniumContainerName));
         }
         try {
+            String hubIpAddress = DockeredSeleniumStarter.getHubIpAddress();
             ContainerInfo containerInfo = dockerClient.inspectContainer(zaleniumContainerId);
             ImmutableMap<String, AttachedNetwork> networks = containerInfo.networkSettings().networks();
             for (Map.Entry<String, AttachedNetwork> networkEntry : networks.entrySet()) {
-                if (!DEFAULT_DOCKER_NETWORK_NAME.equalsIgnoreCase(networkEntry.getKey())) {
+                if (networkEntry.getValue().ipAddress().equalsIgnoreCase(hubIpAddress)) {
                     zaleniumNetwork = networkEntry.getKey();
                     return zaleniumNetwork;
                 }

--- a/src/main/java/de/zalando/ep/zalenium/proxy/DockeredSeleniumStarter.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/DockeredSeleniumStarter.java
@@ -80,6 +80,7 @@ public class DockeredSeleniumStarter {
     private static String dockerSeleniumImageName;
     private static int browserTimeout;
     private static Map<String, String> zaleniumProxyVars = new HashMap<>();
+    private static String hubIpAddress = null;
     
     static {
     	readConfigurationFromEnvVariables();
@@ -257,13 +258,20 @@ public class DockeredSeleniumStarter {
         }
     }
     
+    public static String getHubIpAddress() {
+        if (hubIpAddress == null) {
+            NetworkUtils networkUtils = new NetworkUtils();
+            hubIpAddress = networkUtils.getIp4NonLoopbackAddressOfThisMachine().getHostAddress();
+        }
+        return hubIpAddress;
+    }
+
     public ContainerCreationStatus startDockerSeleniumContainer(final TimeZone timeZone, final Dimension screenSize) {
 
         TimeZone effectiveTimeZone = ObjectUtils.defaultIfNull(timeZone, DEFAULT_TZ);
         Dimension effectiveScreenSize = ObjectUtils.defaultIfNull(screenSize, DEFAULT_SCREEN_SIZE);
 
-        NetworkUtils networkUtils = new NetworkUtils();
-        String hostIpAddress = networkUtils.getIp4NonLoopbackAddressOfThisMachine().getHostAddress();
+        String hostIpAddress = getHubIpAddress();
         String nodePolling = String.valueOf(RandomUtils.nextInt(90, 120) * 1000);
         String nodeRegisterCycle = String.valueOf(RandomUtils.nextInt(60, 90) * 1000);
         String seleniumNodeParams = getSeleniumNodeParameters();


### PR DESCRIPTION
### Description
Expose the hub IP address that is communicated to the nodes in DockeredSeleniumStarter.
In DockerContainerClient use this IP address to determine the correct network to use for creating the nodes.  

### Motivation and Context
Zalenium puts the nodes in the first network it finds on the hub that isn't "bridge" but it tells the nodes to contact it on the first non-loopback interface it finds. These are not necessarily the same network.
This causes the nodes to be unable to connect to the hub to register themselves.

### How Has This Been Tested?
I used Lando (https://github.com/lando/lando) which run a docker-compose setup with multiple networks. Adding zalenium here leads to the issue described in the context.
.lando.yml:
```yaml
name: myproject

recipe: drupal7

config:
  webroot: web
  php: 7.1
  via: apache:2.4
  database: postgres

services:
  zalenium:
    type: compose
    services:
      image: dosel/zalenium
      ports:
        - "4444:4444"
      command: ["entry.sh", "start"]
      volumes:
        - /var/run/docker.sock:/var/run/docker.sock
        - /tmp/mounted:/tmp/mounted
        - /dev/shm:/dev/shm
      environment:
        - PULL_SELENIUM_IMAGE=true
        - SEND_ANONYMOUS_USAGE_INFO=false
        - DEBUG_ENABLED=true
    portforward: true

proxy:
  zalenium:
    - zalenium.lndo.site:4444
```
In this case the hub has 3 networks. Zalenium picks one of them to create the nodes on. It picks a different one to get it's IP address from to communicate to the nodes (SELENIUM_HUB).

Then I did the same with a new zalenium image built from the branch with my changes and the problem went away.
The IP communicated to the nodes is on the same network as the nodes are created on.


### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
