### PR TITLE
Fix typo in dashboard URL

### DIFF
--- a/docs/_posts/2000-01-07-usage.md
+++ b/docs/_posts/2000-01-07-usage.md
@@ -42,7 +42,7 @@ See more details at `build name`.
   <img id="dashboard" src="img/dashboard.gif" />
 </p>
 
-* Go to [http://localhost:4444/grid/dashboard](http://localhost:4444/dashboard){:target="_blank"}
+* Go to [http://localhost:4444/dashboard](http://localhost:4444/dashboard){:target="_blank"}
 <br>
 <br>    
   * You can replace `localhost` for the IP/machine name where Zalenium is running


### PR DESCRIPTION
**Thanks for contributing to Zalenium! Please give us as much information as possible to merge this PR
quickly.**

### Description
The documentation for the dashboard had a typo in the text pointing to the URL.

### Motivation and Context
The URL was incorrect.

### How Has This Been Tested?
There are no instructions for building the documentation, but I can if anybody wants.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
<!--- Provide a general summary of your changes in the Title above -->