### PR TITLE
Add owner information to kubernetes pods

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/container/kubernetes/KubernetesContainerClient.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/kubernetes/KubernetesContainerClient.java
@@ -339,6 +339,7 @@ public class KubernetesContainerClient implements ContainerClient {
         config.setTolerations(tolerations);
         config.setPodLimits(seleniumPodLimits);
         config.setPodRequests(seleniumPodRequests);
+        config.setOwner(zaleniumPod);
         config.setPodSecurityContext(configuredSecurityContext);
 
         DoneablePod doneablePod = createDoneablePod.apply(config);
@@ -552,6 +553,7 @@ public class KubernetesContainerClient implements ContainerClient {
                 .withNewMetadata()
                     .withGenerateName(config.getContainerIdPrefix())
                     .addToLabels(config.getLabels())
+                    .withOwnerReferences(config.getOwnerRef())
                 .endMetadata()
                 .withNewSpec()
                     .withNodeSelector(config.getNodeSelector())

--- a/src/main/java/de/zalando/ep/zalenium/container/kubernetes/PodConfiguration.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/kubernetes/PodConfiguration.java
@@ -8,6 +8,8 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
 
 import java.util.List;
@@ -20,6 +22,7 @@ public class PodConfiguration {
     private String containerIdPrefix;
     private String image;
     private String imagePullPolicy;
+    private String nodePort;
     private List<LocalObjectReference> imagePullSecrets;
     private List<EnvVar> envVars;
     private List<HostAlias> hostAliases;
@@ -29,7 +32,7 @@ public class PodConfiguration {
     private Map<String, Quantity> podRequests;
     private Map<String, String> nodeSelector;
     private List<Toleration> tolerations;
-    private String nodePort;
+    private OwnerReference ownerReference;
     private PodSecurityContext podSecurityContext;
 
     public String getNodePort() {
@@ -39,6 +42,14 @@ public class PodConfiguration {
     public void setNodePort(String nodePort) {
         this.nodePort = nodePort;
     }
+
+    public void setOwner(Pod ownerPod) {
+        this.ownerReference = new OwnerReference(ownerPod.getApiVersion(), false, true, ownerPod.getKind(), ownerPod.getMetadata().getName(), ownerPod.getMetadata().getUid());
+    }
+    public OwnerReference getOwnerRef() {
+        return ownerReference;
+    }
+
     public KubernetesClient getClient() {
         return client;
     }

--- a/src/test/java/de/zalando/ep/zalenium/container/kubernetes/PodConfigurationTest.java
+++ b/src/test/java/de/zalando/ep/zalenium/container/kubernetes/PodConfigurationTest.java
@@ -8,6 +8,8 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -138,6 +140,13 @@ public class PodConfigurationTest {
         podConfiguration.setImagePullSecrets(secrets);
         assertThat(podConfiguration.getImagePullSecrets().size(), is(1));
         assertThat(podConfiguration.getImagePullSecrets().get(0), is(secret));
+    }
+
+    @Test
+    public void setOwner() {
+        Pod ownerPod = mock(Pod.class);
+        podConfiguration.setOwner(ownerPod);
+        assertThat(podConfiguration.getOwnerRef(), is(ownerPod));
     }
     
     @Test


### PR DESCRIPTION
### Description
The following PR provides the Owner information to the Pods scheduled from the Zalenium hub.

### Motivation and Context
It is not possible to safely rotate/drain/cordon kubernetes hosts where selenium pods scheduled via kubernetes without causing an outage to zalenium.

Previously, users attempting to drain a kubernetes node would be presented with the following error:

```
~$  kubectl drain xxxxxxxxxx
node/xxxxxxxxxx cordoned
error: unable to drain node "xxxxxxxxxx", aborting command...

error: pods not managed by ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet (use --force to override): zalenium-4502-yxyxyxyx
```

By adding the ownership and registering the hub as a controller (which it technically is if its creating Pod objects) allows for the draining or kubernetes nodes safely.

### How Has This Been Tested?
I have ran this in a kubernetes cluster both locally and remotely in versions 1.13.0+ with multiple nodes, scaling zalenium to 3 pods and running tests against zalenium.
Following the tests I've successfully been able to to issue a `kubectl drain xxxxx` to drain the workload prior to node termination.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.