### PR TITLE
Fix helm chart defaults for PVCs

### DIFF
--- a/charts/zalenium/values.yaml
+++ b/charts/zalenium/values.yaml
@@ -120,7 +120,7 @@ persistence:
     ##   GKE, AWS & OpenStack)
     ##
     # storageClass: "-"
-    accessMode: ReadWriteMany
+    accessMode: ReadWriteOnce
     size: 2Gi
   video:
     enabled: false
@@ -135,7 +135,7 @@ persistence:
     ##   GKE, AWS & OpenStack)
     ##
     # storageClass: "-"
-    accessMode: ReadWriteMany
+    accessMode: ReadWriteOnce
     size: 10Gi
 
 ingress:


### PR DESCRIPTION
### Description
As part of #884. This updates the default PVC values to `ReadWriteOnce`.

### Motivation and Context
Provisioning a new zalenium instance using the helm chart failes in AWS,GKE & DigitalOcean

### How Has This Been Tested?
Deploying with the customised `values.yaml` via `helm install -n zalenium charts/zalenium`

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.