### PR TITLE
Add log fetching support for BrowserStack

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/dashboard/TestInformation.java
+++ b/src/main/java/de/zalando/ep/zalenium/dashboard/TestInformation.java
@@ -3,6 +3,8 @@ package de.zalando.ep.zalenium.dashboard;
 
 import com.google.common.base.Strings;
 import com.google.gson.JsonObject;
+
+import de.zalando.ep.zalenium.proxy.RemoteLogFile;
 import de.zalando.ep.zalenium.util.CommonProxyUtilities;
 
 import java.util.Date;
@@ -33,6 +35,7 @@ public class TestInformation {
     private String fileExtension;
     private String videoUrl;
     private List<String> logUrls;
+    private List<RemoteLogFile> remoteLogFiles;
     private String videoFolderPath;
     private String logsFolderPath;
     private String testNameNoExtension;
@@ -108,6 +111,10 @@ public class TestInformation {
         return logUrls;
     }
 
+    public List<RemoteLogFile> getRemoteLogFiles() {
+        return remoteLogFiles;
+    }
+
     public String getVideoUrl() {
         return videoUrl;
     }
@@ -146,6 +153,8 @@ public class TestInformation {
             seleniumLogFileName = fileName.concat("selenium-multinode-stderr.log");
         } else if (SAUCE_LABS_PROXY_NAME.equalsIgnoreCase(proxyName)) {
             seleniumLogFileName = fileName.concat("selenium-server.log");
+        } else if (BROWSER_STACK_PROXY_NAME.equalsIgnoreCase(proxyName)){
+            seleniumLogFileName = fileName.concat("selenium.log");
         } else {
             seleniumLogFileName = fileName.concat("not_implemented.log");
         }
@@ -164,6 +173,8 @@ public class TestInformation {
             browserDriverLogFileName = fileName.concat(String.format("%s_driver.log", browser.toLowerCase()));
         } else if (SAUCE_LABS_PROXY_NAME.equalsIgnoreCase(proxyName)) {
             browserDriverLogFileName = fileName.concat("log.json");
+        } else if (BROWSER_STACK_PROXY_NAME.equalsIgnoreCase(proxyName)){
+            browserDriverLogFileName = fileName.concat("browserstack.log");
         } else {
             browserDriverLogFileName = fileName.concat("not_implemented.log");
         }
@@ -260,6 +271,7 @@ public class TestInformation {
         this.videoUrl = builder.videoUrl;
         this.fileExtension = Optional.ofNullable(builder.fileExtension).orElse("");
         this.logUrls = builder.logUrls;
+        this.remoteLogFiles = builder.remoteLogFiles;
         this.screenDimension = Optional.ofNullable(builder.screenDimension).orElse("");
         this.timeZone = Optional.ofNullable(builder.timeZone).orElse("");
         this.build = Optional.ofNullable(builder.build).orElse("");
@@ -287,6 +299,7 @@ public class TestInformation {
         private String testFileNameTemplate;
         private TestStatus testStatus;
         private JsonObject metadata;
+        private List<RemoteLogFile> remoteLogFiles;
 
         public TestInformationBuilder withSeleniumSessionId(String seleniumSessionId) {
             this.seleniumSessionId = seleniumSessionId;
@@ -335,6 +348,11 @@ public class TestInformation {
 
         public TestInformationBuilder withLogUrls(List<String> logUrls) {
             this.logUrls = logUrls;
+            return this;
+        }
+
+        public TestInformationBuilder withRemoteLogFiles(List<RemoteLogFile> remoteLogFiles) {
+            this.remoteLogFiles = remoteLogFiles;
             return this;
         }
 

--- a/src/main/java/de/zalando/ep/zalenium/proxy/BrowserStackRemoteProxy.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/BrowserStackRemoteProxy.java
@@ -107,6 +107,11 @@ public class BrowserStackRemoteProxy extends CloudTestingRemoteProxy {
                 String platformVersion = automation_session.get("os_version").getAsString();
                 String videoUrl = automation_session.get("video_url").getAsString();
                 List<String> logUrls = new ArrayList<>();
+                logUrls.add(automation_session.get("browser_console_logs_url").getAsString());
+
+                List<RemoteLogFile> remoteLogFiles = new ArrayList<>();
+                remoteLogFiles.add(new RemoteLogFile(automation_session.get("logs").getAsString(), "browserstack.log", true));
+                remoteLogFiles.add(new RemoteLogFile(automation_session.get("selenium_logs_url").getAsString(), "selenium.log", false));
                 if (videoUrl.startsWith("http")) {
                     return new TestInformation.TestInformationBuilder()
                         .withSeleniumSessionId(seleniumSessionId)
@@ -120,6 +125,7 @@ public class BrowserStackRemoteProxy extends CloudTestingRemoteProxy {
                         .withFileExtension(getVideoFileExtension())
                         .withVideoUrl(videoUrl)
                         .withLogUrls(logUrls)
+                        .withRemoteLogFiles(remoteLogFiles)
                         .withMetadata(getMetadata())
                         .build();
                 }

--- a/src/main/java/de/zalando/ep/zalenium/proxy/CloudTestingRemoteProxy.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/CloudTestingRemoteProxy.java
@@ -278,10 +278,21 @@ public class CloudTestingRemoteProxy extends DefaultRemoteProxy {
                         getUserNameValue(), getAccessKeyValue(), useAuthenticationToDownloadFile());
                 for (String logUrl : testInformation.getLogUrls()) {
                     String fileName = logUrl.substring(logUrl.lastIndexOf('/') + 1);
+                    // In order to not try to save questionable characters that the filesystem might disagree with
+
+                    if(fileName.contains("?")){
+                        fileName = fileName.substring(0, fileName.indexOf('?'));
+                    }
                     fileNameWithFullPath = testInformation.getLogsFolderPath() + "/" + fileName;
                     commonProxyUtilities.downloadFile(logUrl, fileNameWithFullPath,
-                            getUserNameValue(), getAccessKeyValue(), useAuthenticationToDownloadFile());
+                            getUserNameValue(), getAccessKeyValue(), useAuthenticationToDownloadFile(), 2);
                 }
+                for (RemoteLogFile remoteLogFile : testInformation.getRemoteLogFiles()) {
+                    fileNameWithFullPath = testInformation.getLogsFolderPath() + "/" + remoteLogFile.getLocalFileName();;
+                    commonProxyUtilities.downloadFile(remoteLogFile.getRemoteUrl(), fileNameWithFullPath,
+                            getUserNameValue(), getAccessKeyValue(), remoteLogFile.isAuthenticationRequired(), 2);
+                }
+
                 createFeatureNotImplementedFile(testInformation.getLogsFolderPath());
                 DashboardCollection.updateDashboard(testInformation);
                 addToDashboardCalled = true;

--- a/src/main/java/de/zalando/ep/zalenium/proxy/RemoteLogFile.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/RemoteLogFile.java
@@ -1,0 +1,25 @@
+package de.zalando.ep.zalenium.proxy;
+
+public class RemoteLogFile {
+    private String remoteUrl;
+    private boolean authenticationRequired;
+    private String localFileName;
+
+    public RemoteLogFile(String remoteUrl, String localFileName, boolean authenticationRequired) {
+        this.remoteUrl = remoteUrl;
+        this.localFileName = localFileName;
+        this.authenticationRequired = authenticationRequired;
+    }
+
+    public String getRemoteUrl(){
+        return remoteUrl;
+    }
+
+    public String getLocalFileName(){
+        return localFileName;
+    }
+
+    public boolean isAuthenticationRequired(){
+        return authenticationRequired;
+    }
+}

--- a/src/main/java/de/zalando/ep/zalenium/util/CommonProxyUtilities.java
+++ b/src/main/java/de/zalando/ep/zalenium/util/CommonProxyUtilities.java
@@ -84,14 +84,18 @@ public class CommonProxyUtilities {
         return null;
     }
 
+    public void downloadFile(String fileUrl, String fileNameWithFullPath, String user, String password,
+    boolean authenticate) throws InterruptedException{
+        downloadFile(fileUrl, fileNameWithFullPath, user, password, authenticate, 10);
+    }
+
     /*
         Downloading a file, method adapted from:
         http://code.runnable.com/Uu83dm5vSScIAACw/download-a-file-from-the-web-for-java-files-and-save
      */
     public void downloadFile(String fileUrl, String fileNameWithFullPath, String user, String password,
-                             boolean authenticate)
+                             boolean authenticate, int maxAttempts)
             throws InterruptedException {
-        int maxAttempts = 10;
         int currentAttempts = 0;
         // Videos are usually not ready right away, we put a little sleep to avoid falling into the catch/retry.
         Thread.sleep(1000 * 5);
@@ -105,6 +109,7 @@ public class CommonProxyUtilities {
                     urlConnection.setRequestProperty("Authorization", basicAuth);
                 }
 
+                urlConnection.setRequestProperty("Accept", "*/*");
                 //Code to download
                 InputStream in = new BufferedInputStream(urlConnection.getInputStream());
                 ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/src/test/resources/browserstack_testinformation.json
+++ b/src/test/resources/browserstack_testinformation.json
@@ -15,6 +15,8 @@
     "logs": "https://www.browserstack.com/automate/builds/dfceb784d33931f3e96822de8782c9142001ee2a/sessions/77e51cead8e6e37b0a0feb0dfa69325b2c4acf97/logs",
     "browser_url": "https://www.browserstack.com/automate/builds/dfceb784d33931f3e96822de8782c9142001ee2a/sessions/77e51cead8e6e37b0a0feb0dfa69325b2c4acf97",
     "public_url": "https://www.browserstack.com/automate/builds/dfceb784d33931f3e96822de8782c9142001ee2a/sessions/77e51cead8e6e37b0a0feb0dfa69325b2c4acf97?auth_token=f2f29cf4b3e5dd8cfb7c6a4aaef316c1b7efec703605028c3f5bcda52ef2bee6",
-    "video_url": "https://www.browserstack.com/s3-upload/bs-video-logs-use/s3/77e51cead8e6e37b0a0feb0dfa69325b2c4acf97/video-77e51cead8e6e37b0a0feb0dfa69325b2c4acf97.mp4?AWSAccessKeyId=AKIAIOW7IEY5D4X2OFIA&Expires=1497088589&Signature=tQ9SCH1lgg6FjlBIhlTDwummLWc%3D&response-content-type=video%2Fmp4"
+    "video_url": "https://www.browserstack.com/s3-upload/bs-video-logs-use/s3/77e51cead8e6e37b0a0feb0dfa69325b2c4acf97/video-77e51cead8e6e37b0a0feb0dfa69325b2c4acf97.mp4?AWSAccessKeyId=AKIAIOW7IEY5D4X2OFIA&Expires=1497088589&Signature=tQ9SCH1lgg6FjlBIhlTDwummLWc%3D&response-content-type=video%2Fmp4",
+    "browser_console_logs_url": "https://www.browserstack.com/s3-upload/bs-video-logs-use/s3/77e51cead8e6e37b0a0feb0dfa69325b2c4acf97/video-77e51cead8e6e37b0a0feb0dfa69325b2c4acf97.mp4?AWSAccessKeyId=AKIAIOW7IEY5D4X2OFIA&Expires=1497088589&Signature=tQ9SCH1lgg6FjlBIhlTDwummLWc%3D&response-content-type=video%2Fmp4",
+    "selenium_logs_url": "https://www.browserstack.com/s3-upload/bs-video-logs-use/s3/77e51cead8e6e37b0a0feb0dfa69325b2c4acf97/video-77e51cead8e6e37b0a0feb0dfa69325b2c4acf97.mp4?AWSAccessKeyId=AKIAIOW7IEY5D4X2OFIA&Expires=1497088589&Signature=tQ9SCH1lgg6FjlBIhlTDwummLWc%3D&response-content-type=video%2Fmp4"
   }
 }


### PR DESCRIPTION
### Description
This commit implements BrowserStack support for Selenium and browser driver logs. It does this
by extending the existing implementation to also encapsulate optional authentication for file downloads.

It does not modify existing implementations, in order to keep the blast-radius of the commit as low as possible.

### Motivation and Context
As we're using a limited BrowserStack plan, with only a few users being able to be active. Our develers requested the Selenium and driver logs to be present. This feature tries to add that feature with as small a blast-radius as possible.

### How Has This Been Tested?
This was tested locally using our BrowserStack credentials, I've done my best to try it with several different browsers and devices. If there is a test suite I can run (other than the unit tests) to do more rigorous testing, please let me know!

In terms of impact to other sides of the code, these should be few. The one "concern" I have is the `Accept: */*` I added for in order for log fetching to work. I'm guessing this will have a low impact, but if there we feel like it, I have no problem adding a hook for adding custom Headers for particular file downloads. 

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. *First Java I've written in a while, I don't know if there's a check I can run locally to check for the code style*
- [ ] My change requires a change to the documentation. *To both this one and the one below, I'm unsure if the lack of log fetching is mentioned anywhere in the documentation, or only in usage of Zalenium*
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. *Unsure, I've modified existing tests, and since this particular code path is already tested, it didn't look crazy to leave as is. Do let me know if you want some tests! More than happy to provide!*
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->