### PR TITLE
Issue-904: Passing security context to spawned pod

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/container/kubernetes/KubernetesContainerClient.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/kubernetes/KubernetesContainerClient.java
@@ -12,6 +12,7 @@ import io.fabric8.kubernetes.api.model.HostAlias;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodSecurityContext;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.Volume;
@@ -67,6 +68,7 @@ public class KubernetesContainerClient implements ContainerClient {
     private List<Toleration> tolerations = new ArrayList<>();
     private String imagePullPolicy;
     private List<LocalObjectReference> imagePullSecrets;
+    private PodSecurityContext configuredSecurityContext;
 
     private final Map<String, Quantity> seleniumPodLimits = new HashMap<>();
     private final Map<String, Quantity> seleniumPodRequests = new HashMap<>();
@@ -104,7 +106,7 @@ public class KubernetesContainerClient implements ContainerClient {
             discoverNodeSelector();
             discoverTolerations();
             discoverImagePullSecrets();
-
+            discoverSecurityContext();
             buildResourceMaps();
 
             logger.info(String.format(
@@ -204,6 +206,10 @@ public class KubernetesContainerClient implements ContainerClient {
         }
 
         return hostname;
+    }
+    
+    private void discoverSecurityContext() {
+    	configuredSecurityContext = zaleniumPod.getSpec().getSecurityContext();
     }
 
     @Override
@@ -333,6 +339,7 @@ public class KubernetesContainerClient implements ContainerClient {
         config.setTolerations(tolerations);
         config.setPodLimits(seleniumPodLimits);
         config.setPodRequests(seleniumPodRequests);
+        config.setPodSecurityContext(configuredSecurityContext);
 
         DoneablePod doneablePod = createDoneablePod.apply(config);
 
@@ -549,6 +556,7 @@ public class KubernetesContainerClient implements ContainerClient {
                 .withNewSpec()
                     .withNodeSelector(config.getNodeSelector())
                     .withTolerations(config.getTolerations())
+                    .withSecurityContext(config.getPodSecurityContext())
                     // Add a memory volume that we can use for /dev/shm
                     .addNewVolume()
                         .withName("dshm")

--- a/src/main/java/de/zalando/ep/zalenium/container/kubernetes/PodConfiguration.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/kubernetes/PodConfiguration.java
@@ -1,6 +1,7 @@
 package de.zalando.ep.zalenium.container.kubernetes;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.PodSecurityContext;
 import io.fabric8.kubernetes.api.model.HostAlias;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -29,6 +30,7 @@ public class PodConfiguration {
     private Map<String, String> nodeSelector;
     private List<Toleration> tolerations;
     private String nodePort;
+    private PodSecurityContext podSecurityContext;
 
     public String getNodePort() {
         return nodePort;
@@ -115,4 +117,13 @@ public class PodConfiguration {
     public void setTolerations(final List<Toleration> tolerations) {
         this.tolerations = tolerations;
     }
+
+	public PodSecurityContext getPodSecurityContext() {
+		return podSecurityContext;
+	}
+
+	public void setPodSecurityContext(PodSecurityContext podSecurityContext) {
+		this.podSecurityContext = podSecurityContext;
+	}
+
 }

--- a/src/test/java/de/zalando/ep/zalenium/container/kubernetes/PodConfigurationTest.java
+++ b/src/test/java/de/zalando/ep/zalenium/container/kubernetes/PodConfigurationTest.java
@@ -3,6 +3,7 @@ package de.zalando.ep.zalenium.container.kubernetes;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HostAlias;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.PodSecurityContext;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.Volume;
@@ -137,5 +138,12 @@ public class PodConfigurationTest {
         podConfiguration.setImagePullSecrets(secrets);
         assertThat(podConfiguration.getImagePullSecrets().size(), is(1));
         assertThat(podConfiguration.getImagePullSecrets().get(0), is(secret));
+    }
+    
+    @Test
+    public void testSetPodSecurityContext() {
+        PodSecurityContext securityContext = mock(PodSecurityContext.class);
+        podConfiguration.setPodSecurityContext(securityContext);
+        assertThat(podConfiguration.getPodSecurityContext(), is(securityContext));
     }
 }


### PR DESCRIPTION
**Thanks for contributing to Zalenium! Please give us as much information as possible to merge this PR
quickly.**

<!--- Provide a general summary of your changes in the Title above -->

### Description
This PR passes security context of zalenium pod to selenium hub pods.

### Motivation and Context
Issue: 904

In RBAC enabled K8S cluster where security context is needed zalenium pod
launches without any issue but spawned selenium hub pod fails with the following error -

`Error: container has runAsNonRoot and image has non-numeric user (seluser), cannot verify user is non-root`

It is because the code doesn't pass on security context to this new pod. 

By this addition, both pods will run with the same security context.

### How Has This Been Tested?
I have run this in kubernetes cluster locally (docker for desktop mac) and remote cluster in versions 1.10.11+ with multiple nodes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->