### PR TITLE
Reorder remote dashboard multipart parameters order

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/dashboard/remote/RemoteVideoDashboard.java
+++ b/src/main/java/de/zalando/ep/zalenium/dashboard/remote/RemoteVideoDashboard.java
@@ -24,7 +24,6 @@ public class RemoteVideoDashboard extends RemoteDashboard {
         uploadFile.mimeType = ContentType.create("video/mp4");
         uploadFile.stream = new FileInputStream(Paths.get(testInformation.getVideoFolderPath(), testInformation.getFileName()).toString());
         uploadFile.fileName = testInformation.getFileName();
-        fields.add(uploadFile);
 
         this.setupMetadata(testInformation).addProperty("Type", "video");
 
@@ -32,7 +31,9 @@ public class RemoteVideoDashboard extends RemoteDashboard {
         kvp.keyName = "metadata";
         kvp.mimeType = ContentType.create("application/json");
         kvp.value = jsonToString(testInformation.getMetadata());
+
         fields.add(kvp);
+        fields.add(uploadFile);
 
         this.getFormPoster().post(fields);
     }


### PR DESCRIPTION
When posting to a node.js API endpoint, the metadata is not available
before the file which makes it difficult to use the metadata to
determine the location to store the file. See
https://stackoverflow.com/questions/39589022/node-js-multer-and-req-body-empty


**Thanks for contributing to Zalenium! Please give us as much information as possible to merge this PR
quickly.**

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
Metadata cannot be access in multer due to the file being sent first in the multipart request, in my case I wanted to use the metadata to determine the amazon s3 key to store the video file, which I couldnt due to the above reason.

### How Has This Been Tested?
Unit tests, changes are very simple however

### Types of changes
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->