### PR TITLE
Introducing a dedicated port for WebUI

### DIFF
--- a/charts/zalenium/templates/service.yaml
+++ b/charts/zalenium/templates/service.yaml
@@ -16,7 +16,7 @@ spec:
   sessionAffinity: {{ .Values.hub.serviceSessionAffinity | quote }}
   ports:
   - name: hub
-    port: {{ .Values.hub.port }}
+    port: {{ .Values.hub.svcPort }}
     targetPort: {{ .Values.hub.port }}
   selector:
     app.kubernetes.io/name: {{ include "zalenium.name" . }}

--- a/charts/zalenium/values.yaml
+++ b/charts/zalenium/values.yaml
@@ -20,7 +20,7 @@ hub:
 
   ## Timeout for probe Hub liveness via HTTP request on Hub console
   livenessTimeout: 1
-  
+
   ## Timeout for probe Hub readiness via HTTP request on Hub console
   readinessTimeout: 1
 
@@ -47,6 +47,9 @@ hub:
   ##   Values: ClusterIP, NodePort, LoadBalancer, or ExternalName
   ## ref: https://kubernetes.io/docs/user-guide/services/
   serviceType: "NodePort"
+
+  ## Port on which K8s service is listening on. Zalenium WebUI will be available there.
+  svcPort: 80
 
   ## If serviceType is LoadBalancer:
   ##   Add list of IPs allowed to connect to the service
@@ -93,7 +96,7 @@ hub:
   testingBotSecret: blank
 
   ## Arbitrary environment variables
-  env: 
+  env:
     # FOO: BAR
 
   ## Use Openshift DeploymentConfig instead of Kubernetes Deployment


### PR DESCRIPTION
### Description
These changes will add more flexibility for ports' configuration.

### Motivation and Context
Before, there was only one `port` (a hub was listening on) value available for changing, but the problem is that this value was used for both keys in kubernetes service definition `port` and `targetPort` which not always is desired to be the same.
In a case you have some firewalls in place which allow only certain ports to be accessed - you're in trouble. Also, as it turns out, port 4444 is not available over the internet due to being blocked by many telcos.

### How Has This Been Tested?
Tested within our local dev cluster hosted in AWS, using Helm.
In case of serviceType=LoadBalancer, an ELB will be listening on `svcPort`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->