### PR TITLE
Issue 958

### DIFF
--- a/charts/zalenium/templates/_pod-template.yaml
+++ b/charts/zalenium/templates/_pod-template.yaml
@@ -114,7 +114,7 @@ spec:
           value: {{ .Values.hub.keepOnlyFailedTests | quote }}
         - name: RETENTION_PERIOD
           value: {{ .Values.hub.retentionPeriod | quote }}
-        {{- if (.Values.ingress.path) and (not (eq .Values.ingress.path "/")) }}
+        {{- if .Values.ingress.path }}
         - name: CONTEXT_PATH
           value: {{ .Values.ingress.path | quote }}
         {{- end }}
@@ -160,11 +160,12 @@ spec:
   nodeSelector:
     {{ .Values.nodeSelector.key }}: {{ .Values.nodeSelector.value | quote }}
   {{- end }}
-  {{- if (.Values.tolerations) and (.Values.tolerations.enabled) }}
+  {{- if .Values.tolerations }}
   tolerations:
-    - key: {{ .Values.tolerations.key }}
-      operator: {{ .Values.tolerations.operator }}
-      value: {{ .Values.tolerations.value | quote }}
-      effect: {{ .Values.tolerations.effect }}
+{{ toYaml .Values.tolerations | indent 4 }}
   {{- end }}
+  {{- if .Values.affinity }}
+  affinity:
+{{ toYaml .Values.affinity | indent 4 }}
+  {{- end -}}
 {{- end }}

--- a/charts/zalenium/templates/_pod-template.yaml
+++ b/charts/zalenium/templates/_pod-template.yaml
@@ -160,7 +160,7 @@ spec:
   nodeSelector:
     {{ .Values.nodeSelector.key }}: {{ .Values.nodeSelector.value | quote }}
   {{- end }}
-  {{- if .Values.tolerations.enabled }}
+  {{- if (.Values.tolerations) and (.Values.tolerations.enabled) }}
   tolerations:
     - key: {{ .Values.tolerations.key }}
       operator: {{ .Values.tolerations.operator }}

--- a/charts/zalenium/templates/_pod-template.yaml
+++ b/charts/zalenium/templates/_pod-template.yaml
@@ -47,7 +47,7 @@ spec:
           protocol: TCP
       livenessProbe:
         httpGet:
-          path: {{ if (.Values.ingress.path) and (not (eq .Values.ingress.path "/")) }}{{ .Values.ingress.path }}{{ end }}/grid/console
+          path: {{ if .Values.ingress.path }}{{ .Values.ingress.path }}{{ end }}/grid/console
           port: {{ .Values.hub.port }}
           {{- if eq true .Values.hub.basicAuth.enabled }}
           httpHeaders:
@@ -59,7 +59,7 @@ spec:
         timeoutSeconds: {{ .Values.hub.livenessTimeout }}
       readinessProbe:
         httpGet:
-          path: {{ if (.Values.ingress.path) and (not (eq .Values.ingress.path "/")) }}{{ .Values.ingress.path }}{{ end }}/grid/console
+          path: {{ if .Values.ingress.path }}{{ .Values.ingress.path }}{{ end }}/grid/console
           port: {{ .Values.hub.port }}
           {{- if eq true .Values.hub.basicAuth.enabled }}
           httpHeaders:

--- a/charts/zalenium/templates/_pod-template.yaml
+++ b/charts/zalenium/templates/_pod-template.yaml
@@ -47,7 +47,7 @@ spec:
           protocol: TCP
       livenessProbe:
         httpGet:
-          path: {{ if and (.Values.ingress.path) (not (eq .Values.ingress.path "/")) }}{{ .Values.ingress.path }}{{ end }}/grid/console
+          path: {{ if (.Values.ingress.path) and (not (eq .Values.ingress.path "/")) }}{{ .Values.ingress.path }}{{ end }}/grid/console
           port: {{ .Values.hub.port }}
           {{- if eq true .Values.hub.basicAuth.enabled }}
           httpHeaders:
@@ -59,7 +59,7 @@ spec:
         timeoutSeconds: {{ .Values.hub.livenessTimeout }}
       readinessProbe:
         httpGet:
-          path: {{ if and (.Values.ingress.path) (not (eq .Values.ingress.path "/")) }}{{ .Values.ingress.path }}{{ end }}/grid/console
+          path: {{ if (.Values.ingress.path) and (not (eq .Values.ingress.path "/")) }}{{ .Values.ingress.path }}{{ end }}/grid/console
           port: {{ .Values.hub.port }}
           {{- if eq true .Values.hub.basicAuth.enabled }}
           httpHeaders:
@@ -114,8 +114,10 @@ spec:
           value: {{ .Values.hub.keepOnlyFailedTests | quote }}
         - name: RETENTION_PERIOD
           value: {{ .Values.hub.retentionPeriod | quote }}
+        {{- if (.Values.ingress.path) and (not (eq .Values.ingress.path "/")) }}
         - name: CONTEXT_PATH
           value: {{ .Values.ingress.path | quote }}
+        {{- end }}
         {{- if .Values.hub.sauceLabsEnabled }}
         - name: SAUCE_LABS_ENABLED
           value: {{ .Values.hub.sauceLabsEnabled | quote }}
@@ -158,12 +160,11 @@ spec:
   nodeSelector:
     {{ .Values.nodeSelector.key }}: {{ .Values.nodeSelector.value | quote }}
   {{- end }}
-  {{- if .Values.tolerations }}
+  {{- if .Values.tolerations.enabled }}
   tolerations:
-{{ toYaml .Values.tolerations | indent 4 }}
+    - key: {{ .Values.tolerations.key }}
+      operator: {{ .Values.tolerations.operator }}
+      value: {{ .Values.tolerations.value | quote }}
+      effect: {{ .Values.tolerations.effect }}
   {{- end }}
-  {{- if .Values.affinity }}
-  affinity:
-{{ toYaml .Values.affinity | indent 4 }}
-  {{- end -}}
 {{- end }}

--- a/charts/zalenium/templates/ingress.yaml
+++ b/charts/zalenium/templates/ingress.yaml
@@ -18,8 +18,10 @@ spec:
   - host: {{ .Values.ingress.hostname }}
     http:
       paths:
-      - path: {{ .Values.ingress.path }}
-        backend:
+      - backend:
           serviceName: {{ template "zalenium.fullname" . }}
-          servicePort: {{ .Values.hub.port }}
+          servicePort: {{ .Values.hub.svcPort }}
+        {{- if .Values.ingress.path }}
+        path: {{ .Values.ingress.path }}
+        {{- end }}
 {{- end -}}

--- a/charts/zalenium/values.yaml
+++ b/charts/zalenium/values.yaml
@@ -156,8 +156,8 @@ ingress:
   # If your ingress host name is shared with multiple
   # applications, Enter a path starting with / (eg. /zalenium)
   # If your ingress host name is only for Zalenium,
-  # set the path as / (root)
-  path: /
+  # no need to set path
+  # path: /
   annotations:
     # kubernetes.io/ingress.class: "nginx"
     # kubernetes.io/tls-acme: "true"

--- a/dashboard/js/dashboard.js
+++ b/dashboard/js/dashboard.js
@@ -120,8 +120,7 @@ function setTestInformation($testName, $browser, $browserVersion, $platform, $pr
     }
     screenResolutionTimeZone.append("<span class=\"float-right\"><img alt=\"Retention Date\" src=\"img/retention-date.png\" " +
         "class=\"mr-1\" width=\"48px\" height=\"48px\"><small>" + $retentionDate + "</small></span>");
-
-    if ($build.length > 0) {
+    if ($build.toString().length > 0) {
         const buildElement = $("#build");
         buildElement.html("");
         buildElement.removeClass("p-0");

--- a/src/main/java/de/zalando/ep/zalenium/dashboard/Dashboard.java
+++ b/src/main/java/de/zalando/ep/zalenium/dashboard/Dashboard.java
@@ -21,7 +21,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;

--- a/src/test/java/de/zalando/ep/zalenium/it/ParallelIT.java
+++ b/src/test/java/de/zalando/ep/zalenium/it/ParallelIT.java
@@ -96,10 +96,12 @@ public class ParallelIT  {
         DesiredCapabilities chromeCaps = new DesiredCapabilities();
         chromeCaps.setBrowserName(BrowserType.CHROME);
         chromeCaps.setPlatform(Platform.ANY);
+        chromeCaps.setCapability("build", "2389");
 
         DesiredCapabilities firefoxCaps = new DesiredCapabilities();
         firefoxCaps.setBrowserName(BrowserType.FIREFOX);
         firefoxCaps.setPlatform(Platform.ANY);
+        firefoxCaps.setCapability("build", "sample build");
 
         return new Object[] {chromeCaps, firefoxCaps};
     }


### PR DESCRIPTION
**Thanks for contributing to Zalenium! Please give us as much information as possible to merge this PR
quickly.**

Make Zalenium work with AWS-ALB ingress

### Description
* Ingress
** Update service port in ingress to correct value .Values.hub.svcPort
** Set path only when provided
* Pod Template
** Probe URLs and Context path, add path only when it is required (default is /)
** Also update the 'and' condition syntax
* Values.yaml
** Comment out Path


### Motivation and Context
To get this working in AWS-ALB
I think the ingress svcPort is required for all ingress unless these two values are same .Values.hub.svcPort, .Values.hub.port

### How Has This Been Tested?
Yes I tested this in my Kubernetes cluster in AWS
`helm install --namespace=mynamespace --name=name --values=/tmp/values.yaml zalenium`
And access the Zalenium hub's dashabord, live (/grid/admin/live) and console pages from the ingress

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
Make Zalenium work with AWS-ALB ingress