### PR TITLE
wrap user-supplied values for htpasswd with quotes

### DIFF
--- a/scripts/zalenium.sh
+++ b/scripts/zalenium.sh
@@ -440,7 +440,7 @@ StartUp()
 
     if [ ! -z ${GRID_USER} ] && [ ! -z ${GRID_PASSWORD} ]; then
         echo "Enabling basic auth via startup script..."
-        htpasswd -bc /home/seluser/.htpasswd ${GRID_USER} ${GRID_PASSWORD}
+        htpasswd -bc /home/seluser/.htpasswd "${GRID_USER}" "${GRID_PASSWORD}"
     fi
 
     # In nginx.conf, Replace {{contextPath}} with value of APPEND_CONTEXT_PATH


### PR DESCRIPTION
### Description
If basic auth was enabled but configured with whitespace in the username or password, then basic auth would not actually get enabled. Wrapping the values in quotes solves the issue.

### Motivation and Context
see https://github.com/zalando/zalenium/issues/805

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see https://github.com/zalando/zalenium/issues/805#issuecomment-494523868

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [n/a] My change requires a change to the documentation.
- [n/a] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [n/a] I have added tests to cover my changes.
- [n/a] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->