### PR TITLE
Add empty default value for k8s security contexts

### DIFF
--- a/charts/zalenium/values.yaml
+++ b/charts/zalenium/values.yaml
@@ -29,14 +29,14 @@ hub:
   ## Pod Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ## in case it is running outside openshift, this should fix this https://github.com/zalando/zalenium/issues/631
-  podSecurityContext:
+  podSecurityContext: {}
     ## See all the options here https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#podsecuritycontext-v1-core
     # fsGroup: 1000
     # runAsUser: 1000
     # runAsGroup: 1000
 
   ## Container Security Context
-  containerSecurityContext:
+  containerSecurityContext: {}
     ## See all the options here https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#securitycontext-v1-core
     # capabilities: []
     # privileged: false


### PR DESCRIPTION
**Thanks for contributing to Zalenium! Please give us as much information as possible to merge this PR
quickly.**

<!--- Provide a general summary of your changes in the Title above -->

Sets empty default values for the two security contexts.

### Description

Not having these default values is causing the node pods to not have the 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes #1015 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

We have tested this locally by installing the helm chart with and without the values having defaults.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->