### PR TITLE
Change probes URL to the /status page

### DIFF
--- a/charts/zalenium/templates/_pod-template.yaml
+++ b/charts/zalenium/templates/_pod-template.yaml
@@ -47,7 +47,7 @@ spec:
           protocol: TCP
       livenessProbe:
         httpGet:
-          path: {{ if .Values.ingress.path }}{{ .Values.ingress.path }}{{ end }}/grid/console
+          path: {{ if .Values.ingress.path }}{{ .Values.ingress.path }}{{ end }}/status
           port: {{ .Values.hub.port }}
           {{- if eq true .Values.hub.basicAuth.enabled }}
           httpHeaders:
@@ -59,7 +59,7 @@ spec:
         timeoutSeconds: {{ .Values.hub.livenessTimeout }}
       readinessProbe:
         httpGet:
-          path: {{ if .Values.ingress.path }}{{ .Values.ingress.path }}{{ end }}/grid/console
+          path: {{ if .Values.ingress.path }}{{ .Values.ingress.path }}{{ end }}/status
           port: {{ .Values.hub.port }}
           {{- if eq true .Values.hub.basicAuth.enabled }}
           httpHeaders:


### PR DESCRIPTION
**Thanks for contributing to Zalenium! Please give us as much information as possible to merge this PR
quickly.**

### Description
When creating the console page, Zalenium servlet collects the status of all the nodes. If some of the nodes' proxy is unavailable, then the probe will fail. Using status page makes the Hub probes not relying on the state, health and availability of the node pods.
### Motivation and Context
Solves #1001

### How Has This Been Tested?
Zalenium was deployed with this probes URL and is running smoothly for over a week now.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
