### PR TITLE
Fix condition to get container by remote url

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/container/swarm/SwarmUtilities.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/swarm/SwarmUtilities.java
@@ -67,7 +67,7 @@ public class SwarmUtilities {
         for (Task task : tasks) {
             for (NetworkAttachment networkAttachment : CollectionUtils.emptyIfNull(task.networkAttachments())) {
                 for (String address : networkAttachment.addresses()) {
-                    if (address.startsWith(remoteUrl.getHost())) {
+                    if (address.split("/")[0].equals(remoteUrl.getHost())) {
                         return task.status().containerStatus();
                     }
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
A condition to determine the container of a remote url was weak and could assign a remote url to a false container. We just checked if a network ip of container starts with passed remote url which could lead into assigning container with ip **10.0.8.2** to a remote url **10.0.8.2**13.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix registration of containers to the hub.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually deploying and testing on a manager-worker swarm and a high-available multiple-manager swarm.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->