### PR TITLE
Enable running zalenium in swarm without sudo

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -248,6 +248,7 @@ RUN if [ "${kubernetesSlimVersion}" = "false" ]; then \
         && tar -xzvf docker.tgz \
         && mv docker/docker /usr/bin/docker-${DOCKER_VERSION} \
         && rm -rf docker/ && rm docker.tgz \
+        && ln -s /usr/bin/docker-${DOCKER_VERSION} /usr/bin/docker \
         && docker-${DOCKER_VERSION} --version | grep "${DOCKER_VERSION}"; \
     else \
         echo "Skipping adding Docker because of kubernetes slim mode"; \

--- a/docs/_posts/2000-01-06-docker-swarm.md
+++ b/docs/_posts/2000-01-06-docker-swarm.md
@@ -13,12 +13,8 @@ Setup a [docker swarm](https://docs.docker.com/get-started/part4/) with at least
 
 * One manager and multiple workers. The hub will run on the manager and the 
 created browser containers will run on the workers.
-* A high available docker swarm with multiple managers. The manager that runs the hub will 
-not run any created browser container.
+* A high available docker swarm with multiple managers.
 
-_Info:_ Currently we do not support running created browser containers on the same node as
-the hub. Running the browser containers and the hub on the same node leads to communication
-problems, which we hope to fix soon.
 
 #### Images
 
@@ -45,13 +41,12 @@ version: "3.7"
 services:
   zalenium:
     image: dosel/zalenium
+    user: seluser:<gid> # required when running in a swarm without sudo - use the <gid> of docker group of swarm
     hostname: zalenium
     deploy:
       placement:
         constraints:
             - node.role == manager
-    labels:
-        - "de.zalando.gridRole=hub" # important for us to identify the node which runs zalenium hub
     ports:
         - "4444:4444"
         - "8000:8000" # port for remote debugging zalenium code
@@ -71,11 +66,6 @@ networks:
         attachable: true
 
 {% endhighlight %}
-
-_Info:_ It is important to give the service that runs the zalenium hub the label
-`"de.zalando.gridRole=hub"`. This helps to identify the node which runs the hub
-and created browser containers will not be deployed on this node, which would cause
-communication problems between the hub and the created browser containers.
 
 Video recording and logs are currently not supported, but we hope to re-enable this
 feature with docker swarm.

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -126,15 +126,21 @@ if [ "${__run_with_gosu}" == "true" ]; then
 else
     # We will need sudo to run docker alongside docker
     # because we don't have the matching group and user id (*nix)
-    if [ "${USE_KUBERNETES}" == "false" ]; then
+    if [ "${USE_KUBERNETES}" == "true" ]; then
+        # Removing the 'sudo' in Kubernetes
+        # Replace the current process with zalenium.sh
+        exec ./zalenium.sh "$@"
+    elif [ "${WE_HAVE_SUDO_ACCESS}" == "false" ]; then
+        # Make sure Docker works (without sudo) before continuing
+        docker --version
+        docker -H ${DOCKER_HOST} images elgalu/selenium >/dev/null
+        # Replace the current process with zalenium.sh
+        exec  ./zalenium.sh "$@"
+    else
         # Make sure Docker works (with sudo) before continuing
         docker --version
         sudo docker -H ${DOCKER_HOST} images elgalu/selenium >/dev/null
         # Replace the current process with zalenium.sh
         exec sudo --preserve-env ./zalenium.sh "$@"
-    else
-        # Removing the 'sudo' in Kubernetes
-        # Replace the current process with zalenium.sh
-        exec ./zalenium.sh "$@"
     fi
 fi

--- a/src/main/java/de/zalando/ep/zalenium/container/swarm/SwarmUtilities.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/swarm/SwarmUtilities.java
@@ -67,7 +67,7 @@ public class SwarmUtilities {
         for (Task task : tasks) {
             for (NetworkAttachment networkAttachment : CollectionUtils.emptyIfNull(task.networkAttachments())) {
                 for (String address : networkAttachment.addresses()) {
-                    if (address.startsWith(remoteUrl.getHost())) {
+                    if (address.split("/")[0].equals(remoteUrl.getHost())) {
                         return task.status().containerStatus();
                     }
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Adapt entry.sh and Dockerfile to run Zalenium in a docker swarm without the usage of sudo.
Also the documentation for docker swarm has been updated.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Our internal docker swarm infrastructur has been changed to a more secure environment which doesn't allow the usage of sudo in a container.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running Zalenium in docker swarm with and without sudo.
Starting Zalenium with "docker run".

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->