### PR TITLE
Allow the modification of the hosts file inside a container

### DIFF
--- a/charts/zalenium/README.md
+++ b/charts/zalenium/README.md
@@ -123,7 +123,8 @@ See Zalenium's [usage examples](https://github.com/zalando/zalenium/blob/master/
 | `hub.openshift.route.enabled`  | Set to true if you want to create a route for zalenium | false |
 | `hub.openshift.route.hostname` | If you want to have a specific hostname specify it here | blank |
 | `hub.openshift.route.tls` | Configures tls settings for OpenShift route. Set it to empty if you don't want it | edge termination + redirect |
-
+| `hub.openshift.route.tls` | Configures tls settings for OpenShift route. Set it to empty if you don't want it | edge termination + redirect |
+| `hostAliases` | Allow the modification of the hosts file inside a container | `[]` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/zalenium/templates/_pod-template.yaml
+++ b/charts/zalenium/templates/_pod-template.yaml
@@ -167,6 +167,10 @@ spec:
           mountPath: /home/seluser/videos
         - name: {{ template "zalenium.fullname" . }}-data
           mountPath: /tmp/mounted
+{{- if .Values.hostAliases }}
+  hostAliases:
+{{ toYaml .Values.hostAliases | indent 4 }}
+{{- end }}
   serviceAccountName: {{ template "zalenium.serviceAccountName" . }}
   {{- if .Values.nodeSelector.enabled }}
   nodeSelector:

--- a/charts/zalenium/values.yaml
+++ b/charts/zalenium/values.yaml
@@ -235,3 +235,9 @@ nodeSelector:
 #             values:
 #             - <key-value>
 #         topologyKey: "kubernetes.io/hostname"
+## hostAliases allow the modification of the hosts file inside a container
+##
+hostAliases: []
+# - ip: "127.0.0.1"
+#   hostnames:
+#   - "cosbench.local"


### PR DESCRIPTION
**Thanks for contributing to Zalenium! Please give us as much information as possible to merge this PR
quickly.**
Changes are related to the helm chart to allow the modification of the hosts file inside a container

### Description
Ability to add entries to /etc/hosts file
https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/

### Motivation and Context
Useful in private cluster deployment.

### How Has This Been Tested?
Tested on my own k8s cluster hosted in google cloud

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
