### PR TITLE
#1050: allows SELENIUM_NODE_HOST to be set by environment variable

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/proxy/DockeredSeleniumStarter.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/DockeredSeleniumStarter.java
@@ -55,6 +55,8 @@ public class DockeredSeleniumStarter {
     static final String SELENIUM_NODE_PARAMS = "ZALENIUM_NODE_PARAMS";
     @VisibleForTesting
     static final String DEFAULT_SELENIUM_NODE_PARAMS = "";
+    static final String SELENIUM_NODE_HOST = "SELENIUM_NODE_HOST";
+    static final String DEFAULT_SELENIUM_NODE_HOST = "0.0.0.0";
     private static final int VNC_PORT_GAP = 20000;
     private static final String DEFAULT_ZALENIUM_CONTAINER_NAME = "zalenium";
     private static final String ZALENIUM_CONTAINER_NAME = "ZALENIUM_CONTAINER_NAME";
@@ -84,11 +86,12 @@ public class DockeredSeleniumStarter {
     private static int browserTimeout;
     private static Map<String, String> zaleniumProxyVars = new HashMap<>();
     private static String hubIpAddress = null;
-    
+    private static String seleniumNodeHost = DEFAULT_SELENIUM_NODE_HOST;
+
     static {
-    	readConfigurationFromEnvVariables();
+        readConfigurationFromEnvVariables();
     }
-    
+
     /*
      * Reading configuration values from the env variables, if a value was not provided it falls back to defaults.
      */
@@ -111,13 +114,16 @@ public class DockeredSeleniumStarter {
         String seleniumNodeParams = env.getStringEnvVariable(SELENIUM_NODE_PARAMS, DEFAULT_SELENIUM_NODE_PARAMS);
         setSeleniumNodeParameters(seleniumNodeParams);
 
+        String seleniumNodeHost = env.getStringEnvVariable(SELENIUM_NODE_HOST, DEFAULT_SELENIUM_NODE_HOST);
+        setSeleniumNodeHost(seleniumNodeHost);
+
         setBrowserTimeout(env.getIntEnvVariable("SEL_BROWSER_TIMEOUT_SECS", DEFAULT_SEL_BROWSER_TIMEOUT_SECS));
 
         sendAnonymousUsageInfo = env.getBooleanEnvVariable("ZALENIUM_SEND_ANONYMOUS_USAGE_INFO", false);
 
         addProxyVars();
     }
-    
+
     private static void addProxyVars() {
         Arrays.asList(HTTP_PROXY_ENV_VARS).forEach(httpEnvVar -> {
             String proxyValue = env.getStringEnvVariable(httpEnvVar, null);
@@ -166,7 +172,7 @@ public class DockeredSeleniumStarter {
     public static String getContainerName() {
         return Optional.ofNullable(containerName).orElse(DEFAULT_ZALENIUM_CONTAINER_NAME);
     }
-    
+
     private static void setContainerName(String containerName) {
         DockeredSeleniumStarter.containerName = containerName;
     }
@@ -185,6 +191,14 @@ public class DockeredSeleniumStarter {
 
     public static void setSeleniumNodeParameters(String seleniumNodeParameters) {
         DockeredSeleniumStarter.seleniumNodeParameters = seleniumNodeParameters;
+    }
+
+    public static String getSeleniumNodeHost() {
+        return seleniumNodeHost;
+    }
+
+    public static void setSeleniumNodeHost(String seleniumNodeHost) {
+        DockeredSeleniumStarter.seleniumNodeHost = seleniumNodeHost;
     }
 
     public static int getBrowserTimeout() {
@@ -248,19 +262,19 @@ public class DockeredSeleniumStarter {
 
         // Check and configure time zone capabilities when they have been passed in the test config.
         TimeZone timeZone = getConfiguredTimeZoneFromCapabilities(requestedCapability);
-        
+
         ContainerCreationStatus containerCreationStatus = startDockerSeleniumContainer(timeZone, screenSize);
         if (containerCreationStatus.isCreated()) {
             LOGGER.debug("Created container {} with dimensions {} and tz {}.",
-                containerCreationStatus.getContainerName(), screenSize, timeZone);
-            return containerCreationStatus;        	
+                    containerCreationStatus.getContainerName(), screenSize, timeZone);
+            return containerCreationStatus;
         }
         else {
-        	LOGGER.warn("No container was created, will wait until request is processed again...");
-        	return null;
+            LOGGER.warn("No container was created, will wait until request is processed again...");
+            return null;
         }
     }
-    
+
     public static String getHubIpAddress() {
         if (hubIpAddress == null) {
             NetworkUtils networkUtils = new NetworkUtils();
@@ -284,6 +298,7 @@ public class DockeredSeleniumStarter {
         String nodePolling = String.valueOf(RandomUtils.nextInt(90, 120) * 1000);
         String nodeRegisterCycle = String.valueOf(RandomUtils.nextInt(60, 90) * 1000);
         String seleniumNodeParams = getSeleniumNodeParameters();
+        String seleniumNodeHost = getSeleniumNodeHost();
         String latestImage = getLatestDownloadedImage(getDockerSeleniumImageName());
 
         int containerPort = LOWER_PORT_BOUNDARY;
@@ -291,21 +306,21 @@ public class DockeredSeleniumStarter {
             containerPort = findFreePortInRange();
         }
         Map<String, String> envVars = buildEnvVars(effectiveTimeZone, effectiveScreenSize, hostIpAddress, sendAnonymousUsageInfo,
-            nodePolling, nodeRegisterCycle, seleniumNodeParams, containerPort);
+                nodePolling, nodeRegisterCycle, seleniumNodeParams, seleniumNodeHost, containerPort);
 
         return containerClient.createContainer(getContainerName(), latestImage, envVars, String.valueOf(containerPort));
     }
 
     private Map<String, String> buildEnvVars(TimeZone timeZone, Dimension screenSize, String hostIpAddress,
-            boolean sendAnonymousUsageInfo, String nodePolling, String nodeRegisterCycle,
-            String seleniumNodeParams, int containerPort) {
+                                             boolean sendAnonymousUsageInfo, String nodePolling, String nodeRegisterCycle,
+                                             String seleniumNodeParams, String seleniumNodeHost, int containerPort) {
         final int noVncPort = containerPort + NO_VNC_PORT_GAP;
         final int vncPort = containerPort + VNC_PORT_GAP;
         Map<String, String> envVars = new HashMap<>();
         envVars.put("ZALENIUM", "true");
         envVars.put("SELENIUM_HUB_HOST", hostIpAddress);
         envVars.put("SELENIUM_HUB_PORT", "4445");
-        envVars.put("SELENIUM_NODE_HOST", "0.0.0.0");
+        envVars.put("SELENIUM_NODE_HOST", seleniumNodeHost);
         envVars.put("GRID", "false");
         envVars.put("WAIT_TIMEOUT", "120s");
         envVars.put("PICK_ALL_RANDOM_PORTS", "false");
@@ -343,15 +358,15 @@ public class DockeredSeleniumStarter {
     }
 
     public boolean containerHasStarted(ContainerCreationStatus creationStatus) {
-    	return containerClient.isReady(creationStatus);
+        return containerClient.isReady(creationStatus);
     }
 
     public boolean containerHasFinished(ContainerCreationStatus creationStatus) {
-    	return containerClient.isTerminated(creationStatus);
+        return containerClient.isTerminated(creationStatus);
     }
-    
+
     public void stopContainer(String containerId) {
-    	containerClient.stopContainer(containerId);
+        containerClient.stopContainer(containerId);
     }
 
     /*
@@ -423,7 +438,7 @@ public class DockeredSeleniumStarter {
                 int noVncPortNumber = portNumber + NO_VNC_PORT_GAP;
                 int vncPortNumber = portNumber + VNC_PORT_GAP;
                 if (!allocatedPorts.contains(portNumber) && !allocatedPorts.contains(noVncPortNumber)
-                    && !allocatedPorts.contains(vncPortNumber)) {
+                        && !allocatedPorts.contains(vncPortNumber)) {
                     allocatedPorts.add(portNumber);
                     allocatedPorts.add(noVncPortNumber);
                     allocatedPorts.add(vncPortNumber);

--- a/src/test/java/de/zalando/ep/zalenium/proxy/DockeredSeleniumStarterTest.java
+++ b/src/test/java/de/zalando/ep/zalenium/proxy/DockeredSeleniumStarterTest.java
@@ -127,11 +127,13 @@ public class DockeredSeleniumStarterTest {
         Assert.assertEquals(DockeredSeleniumStarter.DEFAULT_SCREEN_SIZE.getHeight(),
                 DockeredSeleniumStarter.getConfiguredScreenSize().getHeight());
         Assert.assertEquals(DockeredSeleniumStarter.DEFAULT_SCREEN_SIZE.getWidth(),
-            DockeredSeleniumStarter.getConfiguredScreenSize().getWidth());
+                DockeredSeleniumStarter.getConfiguredScreenSize().getWidth());
         Assert.assertEquals(DockeredSeleniumStarter.DEFAULT_TZ.getID(),
-            DockeredSeleniumStarter.getConfiguredTimeZone().getID());
+                DockeredSeleniumStarter.getConfiguredTimeZone().getID());
         Assert.assertEquals(DockeredSeleniumStarter.DEFAULT_SELENIUM_NODE_PARAMS,
-            DockeredSeleniumStarter.getSeleniumNodeParameters());
+                DockeredSeleniumStarter.getSeleniumNodeParameters());
+        Assert.assertEquals(DockeredSeleniumStarter.DEFAULT_SELENIUM_NODE_HOST,
+                DockeredSeleniumStarter.getSeleniumNodeHost());
     }
 
     @Test
@@ -157,15 +159,15 @@ public class DockeredSeleniumStarterTest {
         ZaleniumConfiguration.readConfigurationFromEnvVariables();
 
         Assert.assertEquals(ZaleniumConfiguration.DEFAULT_AMOUNT_DESIRED_CONTAINERS,
-            ZaleniumConfiguration.getDesiredContainersOnStartup());
+                ZaleniumConfiguration.getDesiredContainersOnStartup());
         Assert.assertEquals(ZaleniumConfiguration.DEFAULT_AMOUNT_DOCKER_SELENIUM_CONTAINERS_RUNNING,
-            ZaleniumConfiguration.getMaxDockerSeleniumContainers());
+                ZaleniumConfiguration.getMaxDockerSeleniumContainers());
         Assert.assertEquals(DockeredSeleniumStarter.DEFAULT_SCREEN_SIZE.getHeight(),
-            DockeredSeleniumStarter.getConfiguredScreenSize().getHeight());
+                DockeredSeleniumStarter.getConfiguredScreenSize().getHeight());
         Assert.assertEquals(DockeredSeleniumStarter.DEFAULT_SCREEN_SIZE.getWidth(),
-            DockeredSeleniumStarter.getConfiguredScreenSize().getWidth());
+                DockeredSeleniumStarter.getConfiguredScreenSize().getWidth());
         Assert.assertEquals(DockeredSeleniumStarter.DEFAULT_TZ.getID(),
-            DockeredSeleniumStarter.getConfiguredTimeZone().getID());
+                DockeredSeleniumStarter.getConfiguredTimeZone().getID());
     }
 
     @Test
@@ -178,6 +180,7 @@ public class DockeredSeleniumStarterTest {
         int screenHeight = 810;
         int browserTimeout = 1000;
         String seleniumNodeParams = "-debug";
+        String seleniumNodeHost = "0.0.0.0";
         TimeZone timeZone = TimeZone.getTimeZone("America/Montreal");
         when(environment.getEnvVariable(ZaleniumConfiguration.ZALENIUM_DESIRED_CONTAINERS))
                 .thenReturn(String.valueOf(amountOfDesiredContainers));
@@ -191,6 +194,8 @@ public class DockeredSeleniumStarterTest {
                 .thenReturn(timeZone.getID());
         when(environment.getEnvVariable(DockeredSeleniumStarter.SELENIUM_NODE_PARAMS))
                 .thenReturn(seleniumNodeParams);
+        when(environment.getEnvVariable(DockeredSeleniumStarter.SELENIUM_NODE_HOST))
+                .thenReturn(seleniumNodeHost);
         when(environment.getEnvVariable("SEL_BROWSER_TIMEOUT_SECS"))
                 .thenReturn(String.valueOf(browserTimeout));
         when(environment.getIntEnvVariable(any(String.class), any(Integer.class))).thenCallRealMethod();
@@ -206,6 +211,7 @@ public class DockeredSeleniumStarterTest {
         Assert.assertEquals(screenWidth, DockeredSeleniumStarter.getConfiguredScreenSize().getWidth());
         Assert.assertEquals(timeZone.getID(), DockeredSeleniumStarter.getConfiguredTimeZone().getID());
         Assert.assertEquals(seleniumNodeParams, DockeredSeleniumStarter.getSeleniumNodeParameters());
+        Assert.assertEquals(seleniumNodeHost, DockeredSeleniumStarter.getSeleniumNodeHost());
         Assert.assertEquals(browserTimeout, DockeredSeleniumStarter.getBrowserTimeout());
     }
 
@@ -222,17 +228,17 @@ public class DockeredSeleniumStarterTest {
         Assert.assertEquals(ZaleniumConfiguration.DEFAULT_AMOUNT_DESIRED_CONTAINERS,
                 ZaleniumConfiguration.getDesiredContainersOnStartup());
         Assert.assertEquals(ZaleniumConfiguration.DEFAULT_AMOUNT_DOCKER_SELENIUM_CONTAINERS_RUNNING,
-            ZaleniumConfiguration.getMaxDockerSeleniumContainers());
+                ZaleniumConfiguration.getMaxDockerSeleniumContainers());
         Assert.assertEquals(DockeredSeleniumStarter.DEFAULT_SCREEN_SIZE.getWidth(),
-            DockeredSeleniumStarter.getConfiguredScreenSize().getWidth());
+                DockeredSeleniumStarter.getConfiguredScreenSize().getWidth());
         Assert.assertEquals(DockeredSeleniumStarter.DEFAULT_SCREEN_SIZE.getHeight(),
-            DockeredSeleniumStarter.getConfiguredScreenSize().getHeight());
+                DockeredSeleniumStarter.getConfiguredScreenSize().getHeight());
         Assert.assertEquals(ZaleniumConfiguration.DEFAULT_TIME_TO_WAIT_TO_START,
-            ZaleniumConfiguration.getTimeToWaitToStart());
+                ZaleniumConfiguration.getTimeToWaitToStart());
         Assert.assertEquals(ZaleniumConfiguration.DEFAULT_TIMES_TO_PROCESS_REQUEST,
-            ZaleniumConfiguration.getMaxTimesToProcessRequest());
+                ZaleniumConfiguration.getMaxTimesToProcessRequest());
         Assert.assertEquals(ZaleniumConfiguration.DEFAULT_CHECK_CONTAINERS_INTERVAL,
-            ZaleniumConfiguration.getCheckContainersInterval());
+                ZaleniumConfiguration.getCheckContainersInterval());
         Assert.assertTrue(ZaleniumConfiguration.isWaitForAvailableNodes());
         Assert.assertEquals(DockeredSeleniumStarter.DEFAULT_SEL_BROWSER_TIMEOUT_SECS,
                 DockeredSeleniumStarter.getBrowserTimeout());


### PR DESCRIPTION
**Thanks for contributing to Zalenium! Please give us as much information as possible to merge this PR
quickly.**

Allows setting the SELENIUM_NODE_HOST environment variable so that dynamic ip config can be used by the `elgalu/docker-selenium` image.  This is to overcome an issue with Azure Container Instance having two IP's.  

Note: The changes are backward compatible and if the SELENIUM_NODE_HOST is not set, then it falls back to the previous value of `0.0.0.0`.

### Motivation and Context
This will allow running the zalenium hub on kubernetes and the nodes to run on azure container instance.

### How Has This Been Tested?
Added unit tests and tested manually using docker hub image `joepaolini/zalenium:1.2` on azure kubernetes service.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->