### PR TITLE
Initial implemenation of custom nginx error pages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -366,7 +366,7 @@ ENV ZAL_VER="${project.build.finalName}" \
     SELENIUM_WAIT_FOR_CONTAINER="true"
 
 COPY entry.sh log warn error /usr/bin/
-COPY nginx.conf /home/seluser/
+COPY nginx.conf error.html /home/seluser/
 COPY css/ /home/seluser/css/
 COPY js/ /home/seluser/js/
 COPY img/ /home/seluser/img/

--- a/docker/error.html
+++ b/docker/error.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Zalenium - <!--# echo var="status" default="" -->
+  <!--# if expr="$status_text" -->
+    - <!--# echo var="status_text" -->
+  <!--# endif -->
+  </title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    h1 { text-align: center; }
+    address { text-align: center; }
+  </style>
+</head>
+<body>
+  <h1><!--# echo var="status" -->
+  <!--# if expr="$status_text" -->
+    - <!--# echo var="status_text" -->
+  <!--# endif -->
+  </h1>
+<hr>
+<address>nginx/<!--# echo var="nginx_version" --> - Zalenium {{zaleniumVersion}}</address>
+</body>
+</html>

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -10,9 +10,26 @@ http {
     proxy_read_timeout          900s;
     send_timeout                900s;
 
+    map $status $status_text {
+        400 'Bad Request';
+        401 'Unauthorized';
+        403 'Forbidden';
+        404 'Not Found';
+        405 'Method Not Allowed';
+        406 'Not Acceptable';
+        413 'Payload Too Large';
+        414 'URI Too Long';
+        431 'Request Header Fields Too Large';
+        500 'Internal Server Error';
+        501 'Not Implemented';
+        502 'Bad Gateway';
+        503 'Service Unavailable';
+        504 'Gateway Timeout';
+    }
+
     server {
         listen 4444;
-        
+
         satisfy any;
         allow 127.0.0.1;
         auth_basic_user_file        /home/seluser/.htpasswd;
@@ -23,6 +40,16 @@ http {
             set $auth_basic off;
         }
         auth_basic $auth_basic;
+
+        error_page 400 401 402 403 404 405 406 407 408 409 410 411 412 413 414
+            415 416 417 418 421 422 423 424 426 428 429 431 451 500 501 502 503
+            504 505 506 507 508 510 511 /error.html;
+
+        location = /error.html {
+            ssi on;
+            internal;
+            alias /home/seluser/error.html;
+        }
 
         location  {{contextPath}}/ {
             rewrite  ^{{contextPath}}/(.*) /$1 break;

--- a/scripts/zalenium.sh
+++ b/scripts/zalenium.sh
@@ -489,6 +489,7 @@ StartUp()
     # In nginx.conf, Replace {{contextPath}} with value of APPEND_CONTEXT_PATH
     sed -i.bak "s~{{contextPath}}~${CONTEXT_PATH}~" /home/seluser/nginx.conf
     sed -i.bak "s~{{nginxMaxBodySize}}~${NGINX_MAX_BODY_SIZE}~" /home/seluser/nginx.conf
+    sed -i.bak "s~{{zaleniumVersion}}~${project.version}~" /home/seluser/error.html
 
     echo "Starting Nginx reverse proxy..."
     nginx -c /home/seluser/nginx.conf

--- a/scripts/zalenium.sh
+++ b/scripts/zalenium.sh
@@ -83,7 +83,7 @@ WaitSeleniumHub()
     # Other option is to wait for certain text at
     #  logs/stdout.zalenium.hub.log
     while ! curl -sSL "http://localhost:4444${CONTEXT_PATH}/wd/hub/status" 2>&1 \
-            | jq -r '.status' 2>&1 | grep "0" >/dev/null; do
+            | jq -r '.status' 2>/dev/null | grep "0" >/dev/null; do
         echo -n '.'
         sleep 0.2
     done


### PR DESCRIPTION
### Description

This adds a simple Zalenium-specific error page (idea from https://blog.adriaan.io/one-nginx-error-page-to-rule-them-all.html), nothing fancy, maybe someone else wants to add some style.

![grafik](https://user-images.githubusercontent.com/78534/66276793-4876e280-e896-11e9-8a25-31e26396a89a.png)

### Motivation and Context

When debugging issues in a Kubernetes cluster, you always see the default nginx error pages, because nginx is everywhere. Sometime it's hard to know which system created the error, so this makes it possible at first glance to see if the error was in Zalenium or Kubernetes.

### How Has This Been Tested?

Built a container, but only manually tested that the nginx config works.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.