### PR TITLE
EKS scaleup issues

### DIFF
--- a/charts/zalenium/templates/_pod-template.yaml
+++ b/charts/zalenium/templates/_pod-template.yaml
@@ -102,6 +102,8 @@ spec:
           value: {{ .Values.hub.screenHeight | quote }}
         - name: MAX_TEST_SESSIONS
           value: {{ .Values.hub.maxTestSessions | quote }}
+        - name: MAX_TEST_IDLE_TIME_SECS
+          value: {{ .Values.hub.maxTestIdleTimeSecs| quote }}
         - name: NEW_SESSION_WAIT_TIMEOUT
           value: {{ .Values.hub.newSessionsWaitTimeout | quote }}
         - name: DEBUG_ENABLED

--- a/charts/zalenium/values.yaml
+++ b/charts/zalenium/values.yaml
@@ -93,6 +93,7 @@ hub:
   seleniumImageName: "elgalu/selenium"
   maxTestSessions: 1
   newSessionsWaitTimeout: 600000
+  maxTestIdleTimeSecs: 90
   debugEnabled: false
   keepOnlyFailedTests: false
   retentionPeriod: 3

--- a/scripts/zalenium.sh
+++ b/scripts/zalenium.sh
@@ -3,6 +3,7 @@
 CONTAINER_NAME="zalenium"
 SELENIUM_IMAGE_NAME=${SELENIUM_IMAGE_NAME:-"elgalu/selenium"}
 MAX_TEST_SESSIONS=${MAX_TEST_SESSIONS:-1}
+MAX_TEST_IDLE_TIME_SECS=${MAX_TEST_IDLE_TIME_SECS:-90}
 DESIRED_CONTAINERS=${DESIRED_CONTAINERS:-2}
 MAX_DOCKER_SELENIUM_CONTAINERS=${MAX_DOCKER_SELENIUM_CONTAINERS:-10}
 SWARM_OVERLAY_NETWORK=${SWARM_OVERLAY_NETWORK:-""}
@@ -433,6 +434,7 @@ StartUp()
     export ZALENIUM_CONTAINER_NAME=${CONTAINER_NAME}
     export ZALENIUM_SELENIUM_IMAGE_NAME=${SELENIUM_IMAGE_NAME}
     export ZALENIUM_MAX_TEST_SESSIONS=${MAX_TEST_SESSIONS}
+    export ZALENIUM_MAX_TEST_IDLE_TIME_SECS=${MAX_TEST_IDLE_TIME_SECS}
     export ZALENIUM_KEEP_ONLY_FAILED_TESTS=${KEEP_ONLY_FAILED_TESTS}
     export ZALENIUM_RETENTION_PERIOD=${RETENTION_PERIOD}
     export ZALENIUM_NODE_PARAMS=${SELENIUM_NODE_PARAMS}
@@ -708,7 +710,7 @@ StartUp()
         # Gathering the options used to start Zalenium, in order to learn about the used options
         ZALENIUM_START_COMMAND="zalenium.sh --desiredContainers $DESIRED_CONTAINERS
             --maxDockerSeleniumContainers $MAX_DOCKER_SELENIUM_CONTAINERS --maxTestSessions $MAX_TEST_SESSIONS
-            --swarmOverlayNetwork $SWARM_OVERLAY_NETWORK
+            --maxTestIdleTimeSecs $MAX_TEST_IDLE_TIME_SECS --swarmOverlayNetwork $SWARM_OVERLAY_NETWORK
             --sauceLabsEnabled $SAUCE_LABS_ENABLED --browserStackEnabled $BROWSER_STACK_ENABLED
             --testingBotEnabled $TESTINGBOT_ENABLED --cbtEnabled $CBT_ENABLED
             --lambdaTestEnabled $LT_ENABLED
@@ -939,6 +941,7 @@ function usage()
     echo -e "\t --gridUser -> allows you to specify a user to enable basic auth protection, --gridPassword must be provided also."
     echo -e "\t --gridPassword -> allows you to specify a password to enable basic auth protection, --gridUser must be provided also."
     echo -e "\t --maxTestSessions -> max amount of tests executed per container, defaults to '1'."
+    echo -e "\t --maxTestIdleTimeSecs-> Time without activity in the session creation or between commands before shuting down the node by inactivity, defaults to '90'."
     echo -e "\t --keepOnlyFailedTests -> Keeps only videos of failed tests (you need to send a cookie). Defaults to 'false'"
  	echo -e "\t --retentionPeriod -> Number of day's a testentry should be kept in dashboard before cleanup. Defaults to 3"
     echo ""
@@ -1035,6 +1038,9 @@ case ${SCRIPT_ACTION} in
                     ;;
                 --maxTestSessions)
                     MAX_TEST_SESSIONS=${VALUE}
+                    ;;
+                --maxTestIdleTimeSecs)
+                    MAX_TEST_IDLE_TIME_SECS=${VALUE}
                     ;;
                 --keepOnlyFailedTests)
                     KEEP_ONLY_FAILED_TESTS=${VALUE}

--- a/src/main/java/de/zalando/ep/zalenium/container/ContainerClient.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/ContainerClient.java
@@ -27,4 +27,6 @@ public interface ContainerClient {
     boolean isReady(ContainerCreationStatus container);
     
     boolean isTerminated(ContainerCreationStatus container);
+
+    String getContainerIdByIp(String host);
 }

--- a/src/main/java/de/zalando/ep/zalenium/container/DockerContainerClient.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/DockerContainerClient.java
@@ -670,5 +670,11 @@ public class DockerContainerClient implements ContainerClient {
             return false;
         }
     }
+
+    @Override
+    public String getContainerIdByIp(String host) {
+        // TODO Auto-generated method stub
+        return null;
+    }
 }
 

--- a/src/main/java/de/zalando/ep/zalenium/container/kubernetes/KubernetesContainerClient.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/kubernetes/KubernetesContainerClient.java
@@ -4,16 +4,20 @@ import de.zalando.ep.zalenium.container.ContainerClient;
 import de.zalando.ep.zalenium.container.ContainerClientRegistration;
 import de.zalando.ep.zalenium.container.ContainerCreationStatus;
 import de.zalando.ep.zalenium.util.Environment;
+import io.fabric8.kubernetes.api.model.BaseKubernetesListFluent.KubernetesClusterRoleItemsNested;
+import io.fabric8.kubernetes.api.model.ContainerStateRunning;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.DoneablePod;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HostAlias;
+import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.PodSecurityContext;
+import io.fabric8.kubernetes.api.model.PodStatus;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.api.model.Toleration;
@@ -40,6 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -414,6 +419,26 @@ public class KubernetesContainerClient implements ContainerClient {
         }
     }
 
+    public PodStatus getPodStatus(ContainerCreationStatus container) {
+        Pod pod = client.pods().withName(container.getContainerName()).get();
+        if (pod == null) {
+            logger.debug("Pod not found {}", container);
+            return null;
+        } else {
+            return pod.getStatus();
+        }
+    }   
+
+    public String getContainerIdByIp(String PodIP) {
+        for(Pod pod : client.pods().list().getItems()) {
+            if (PodIP != null && PodIP.equals(pod.getStatus().getPodIP())) {
+                return pod.getMetadata().getName();
+            }
+        }
+        logger.debug("Pod not found by Ip {}", PodIP);
+        return null;
+    }   
+
     public boolean isTerminated(ContainerCreationStatus container) {
         Pod pod = client.pods().withName(container.getContainerName()).get();
         if (pod == null) {
@@ -450,9 +475,13 @@ public class KubernetesContainerClient implements ContainerClient {
         for (Pod pod : list.getItems()) {
 
             if (podIpAddress.equals(pod.getStatus().getPodIP())) {
+                if ("Running".equals(pod.getStatus().getPhase())) {
                 containerId = pod.getMetadata().getName();
                 currentPod = pod;
                 break;
+                } else {
+                    logger.warn("Pod {} ip duplicated", pod.getMetadata().getName());
+                }
             }
         }
 
@@ -529,7 +558,7 @@ public class KubernetesContainerClient implements ContainerClient {
 
         public void waitForInputStreamToConnect() {
             try {
-                this.openLatch.await();
+                this.openLatch.await(10, TimeUnit.SECONDS);
             }
             catch (InterruptedException e) {
                 logger.error( String.format("%s Failed to execute command %s", containerId, Arrays.toString(command)), e);
@@ -610,16 +639,24 @@ public class KubernetesContainerClient implements ContainerClient {
                         .endResources()
                         // Add a readiness health check so that we can know when the selenium pod is ready to accept requests
                         // so then we can initiate a registration.
-                        .withNewReadinessProbe()
-                            .withNewExec()
-                                .addToCommand(new String[] {"/bin/sh", "-c", "http_proxy=\"\" curl -s http://`hostname -i`:"
-                                        + config.getNodePort() + "/wd/hub/status | jq .value.ready | grep true"})
-                            .endExec()
-                            .withInitialDelaySeconds(5)
-                            .withFailureThreshold(60)
-                            .withPeriodSeconds(1)
+                        .withNewLivenessProbe()
+                            .withInitialDelaySeconds(30)
                             .withTimeoutSeconds(5)
+                            .withNewHttpGet()
+                                .withPath("/wd/hub/status")
+                                .withPort(new IntOrString(40000))
+                            .endHttpGet()
+                        .endLivenessProbe()
+                        .withNewReadinessProbe()
+                            .withInitialDelaySeconds(5)
+                            .withFailureThreshold(2)
+                            .withPeriodSeconds(2)
+                            .withTimeoutSeconds(10)
                             .withSuccessThreshold(1)
+                            .withNewHttpGet()
+                                .withPath("/wd/hub/status")
+                                .withPort(new IntOrString(40000))
+                            .endHttpGet()
                         .endReadinessProbe()
                     .endContainer()
                     .withRestartPolicy("Never")

--- a/src/main/java/de/zalando/ep/zalenium/container/swarm/SwarmContainerClient.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/swarm/SwarmContainerClient.java
@@ -476,5 +476,11 @@ public class SwarmContainerClient implements ContainerClient {
             return false;
         }
     }
+
+    @Override
+    public String getContainerIdByIp(String host) {
+        // TODO Auto-generated method stub
+        return null;
+    }
 }
 

--- a/src/main/java/de/zalando/ep/zalenium/proxy/DockerSeleniumRemoteProxy.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/DockerSeleniumRemoteProxy.java
@@ -470,10 +470,10 @@ public class DockerSeleniumRemoteProxy extends DefaultRemoteProxy {
 
     public boolean shutdownIfIdle() {
         String currentName = configureThreadName();
-        boolean condition = isTestIdleMoreThan(900) && !isCleaningUp() && !isBusy();
+        boolean condition = isTestIdleMoreThan(600) && !isCleaningUp() && !isBusy();
         if (condition) {
             String msg = String.format("Node %s has been idle for %s seconds. "
-                    + "Shutdown", this.getContainerId(), 900);
+                    + "Shutdown", this.getContainerId(), 600);
             LOGGER.debug(msg);
             timeout(msg, ShutdownType.IDLE);
         }

--- a/src/main/java/de/zalando/ep/zalenium/proxy/DockerSeleniumRemoteProxy.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/DockerSeleniumRemoteProxy.java
@@ -15,7 +15,6 @@ import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import de.zalando.ep.zalenium.container.swarm.SwarmUtilities;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.lang3.StringUtils;
@@ -500,7 +499,9 @@ public class DockerSeleniumRemoteProxy extends DefaultRemoteProxy {
         String currentName = configureThreadName();
         String host = getRemoteHost().getHost();
         String containerIdByIp = this.containerClient.getContainerIdByIp(host);
-        if (containerIdByIp == null || ! containerIdByIp.equals(containerId)) {
+        if (containerIdByIp != null
+                && ! "null".contentEquals(containerId)
+                && ! containerIdByIp.equals(containerId)) {
             LOGGER.warn("{} has the containerId {} but {} was expected.",
                     host, containerIdByIp, containerId);
             timeout("proxy is corrupted.", ShutdownType.CORRUPTED);

--- a/src/main/java/de/zalando/ep/zalenium/proxy/DockeredSeleniumStarter.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/DockeredSeleniumStarter.java
@@ -300,7 +300,7 @@ public class DockeredSeleniumStarter {
 
         String hostIpAddress = getHubIpAddress();
         String nodePolling = String.valueOf(RandomUtils.nextInt(90, 120) * 1000);
-        String nodeRegisterCycle = String.valueOf(RandomUtils.nextInt(60, 90) * 1000);
+        String nodeRegisterCycle = String.valueOf(RandomUtils.nextInt(1000, 10000));
         String seleniumNodeParams = getSeleniumNodeParameters();
         String seleniumNodeHost = getSeleniumNodeHost();
         String latestImage = getLatestDownloadedImage(getDockerSeleniumImageName());

--- a/src/main/java/de/zalando/ep/zalenium/proxy/DockeredSeleniumStarter.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/DockeredSeleniumStarter.java
@@ -365,16 +365,6 @@ public class DockeredSeleniumStarter {
         return containerClient.isReady(creationStatus);
     }
     
-    public PodStatus getPodStatus(ContainerCreationStatus creationStatus) {
-        if (containerClient instanceof KubernetesContainerClient) {
-            KubernetesContainerClient client =  (KubernetesContainerClient) containerClient;
-            return client.getPodStatus(creationStatus);
-        } else {
-            LOGGER.debug("Container is not KubernetesContainerClient");
-            return null;
-        }
-    }
-
     public boolean containerHasFinished(ContainerCreationStatus creationStatus) {
         return containerClient.isTerminated(creationStatus);
     }

--- a/src/main/java/de/zalando/ep/zalenium/proxy/DockeredSeleniumStarter.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/DockeredSeleniumStarter.java
@@ -11,6 +11,7 @@ import java.util.TimeZone;
 
 import com.spotify.docker.client.messages.ContainerInfo;
 import de.zalando.ep.zalenium.container.DockerContainerClient;
+import de.zalando.ep.zalenium.container.kubernetes.KubernetesContainerClient;
 import de.zalando.ep.zalenium.container.swarm.SwarmContainerClient;
 import de.zalando.ep.zalenium.container.swarm.SwarmUtilities;
 import org.apache.commons.lang3.ObjectUtils;
@@ -30,6 +31,9 @@ import de.zalando.ep.zalenium.container.ContainerCreationStatus;
 import de.zalando.ep.zalenium.container.ContainerFactory;
 import de.zalando.ep.zalenium.matcher.ZaleniumCapabilityType;
 import de.zalando.ep.zalenium.util.Environment;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -359,6 +363,16 @@ public class DockeredSeleniumStarter {
 
     public boolean containerHasStarted(ContainerCreationStatus creationStatus) {
         return containerClient.isReady(creationStatus);
+    }
+    
+    public PodStatus getPodStatus(ContainerCreationStatus creationStatus) {
+        if (containerClient instanceof KubernetesContainerClient) {
+            KubernetesContainerClient client =  (KubernetesContainerClient) containerClient;
+            return client.getPodStatus(creationStatus);
+        } else {
+            LOGGER.debug("Container is not KubernetesContainerClient");
+            return null;
+        }
     }
 
     public boolean containerHasFinished(ContainerCreationStatus creationStatus) {

--- a/src/main/java/de/zalando/ep/zalenium/registry/ZaleniumRegistry.java
+++ b/src/main/java/de/zalando/ep/zalenium/registry/ZaleniumRegistry.java
@@ -262,7 +262,6 @@ public class ZaleniumRegistry extends BaseGridRegistry implements GridRegistry {
      */
     public void addNewSessionRequest(RequestHandler handler) {
         try {
-            lock.lock();
             Map<String, Object> requestedCapabilities = handler.getRequest().getDesiredCapabilities();
 
             //Prefix custom capabilities and truncate them when they are longer than 250 characters

--- a/src/test/java/de/zalando/ep/zalenium/proxy/DockerSeleniumRemoteProxyTest.java
+++ b/src/test/java/de/zalando/ep/zalenium/proxy/DockerSeleniumRemoteProxyTest.java
@@ -234,6 +234,27 @@ public class DockerSeleniumRemoteProxyTest {
     }
 
     @Test
+    public void testIdleTimeoutUsesEnvValueWhenEnvIsPresent() {
+        try {
+            Environment environment = mock(Environment.class, withSettings().useConstructor());
+            when(environment.getIntEnvVariable(DockerSeleniumRemoteProxy.ZALENIUM_MAX_TEST_IDLE_TIME_SECS,
+                    DockerSeleniumRemoteProxy.DEFAULT_MAX_TEST_IDLE_TIME_SECS))
+                    .thenReturn(301);
+            when(environment.getIntEnvVariable(DockerSeleniumRemoteProxy.ZALENIUM_MAX_TEST_SESSIONS, 1))
+            .thenReturn(1);          
+            DockerSeleniumRemoteProxy.setEnv(environment);
+            DockerSeleniumRemoteProxy.readEnvVars();
+            
+            Map<String, Object> requestedCapability = getCapabilitySupportedByDockerSelenium();
+            TestSession newSession = proxy.getNewSession(requestedCapability);
+            Assert.assertNotNull(newSession);
+            Assert.assertEquals(proxy.getMaxTestIdleTimeSecs(), 301);
+        } finally {
+            DockerSeleniumRemoteProxy.restoreEnvironment();
+        }
+    }
+
+    @Test
     public void testIdleTimeoutUsesDefaultValueWhenCapabilityHasNegativeValue() {
         Map<String, Object> requestedCapability = getCapabilitySupportedByDockerSelenium();
         requestedCapability.put("idleTimeout", -20L);

--- a/src/test/java/de/zalando/ep/zalenium/util/KubernetesContainerMock.java
+++ b/src/test/java/de/zalando/ep/zalenium/util/KubernetesContainerMock.java
@@ -128,7 +128,7 @@ public class KubernetesContainerMock {
                 .build();
         dockerSeleniumPod.setSpec(dockerSeleniumPodSpec);
 
-        PodStatus dockerSeleniumPodStatus = new PodStatusBuilder().withPodIP("localhost").build();
+        PodStatus dockerSeleniumPodStatus = new PodStatusBuilder().withPodIP("localhost").withPhase("Running").build();
         dockerSeleniumPod.setStatus(dockerSeleniumPodStatus);
 
         server.expect()


### PR DESCRIPTION
When you try to scale up Zalenium to more than 400 pods some concurrency and race conditions issues appears.

* Avoid race conditions in registration process
	- Kubernetes has eventual consistency, Zalenium can receive an registration request from a POD which is still not ready in eks
	- TearDown already registered nodes at ZaleniumRegistry

	ZaleniumRegistry.add
	AutoStartProxySet.register & checkContainers

* Increase HTTP Timeouts to avoid problems under load
	seconds -> milliseconds

*  Avoid java.lang.OutOfMemoryError: unable to create new native thread
	Use thread pool in AutoStartProxySet start method.

*  Separate stale and idle timeout. Differentiate two times of timeouts, one for sessions without activity a specific interval of time (stale/idle timeout)  and other for nodes without activity (pool timeout)
	DockerSeleniumRemoteProxy

*  Avoid get stuck while reading stream - Add waitForInputStreamToConnect timeout
	KubernetesContainerClient

* Several checkContainers and register race conditions
	Pod is register while shutdowning node registration took too long
	Pod is not mark has idle is connection is closed by the client while it was waiting for a session.
	Pod is marked as stuck even when the number of pods is equal or lower to the minimum.
	Differentiate two times of timeouts, one for sessions without activity a specific interval of time (stale/idle timeout)  and other for nodes without activity (pool timeout) to avoid kill pods which are still scaling (in eks the scaleup can take more than 90s).

* Avoid file names too long and repeat process same requests
	Prefix custom capabilities and truncate them when they are longer than 250 characters in addNewSessionRequest



