### PR TITLE
feature(): use custom scheduller in k8s

### DIFF
--- a/charts/zalenium/templates/_pod-template.yaml
+++ b/charts/zalenium/templates/_pod-template.yaml
@@ -5,6 +5,10 @@ metadata:
   annotations:
     {{- toYaml .Values.hub.podAnnotations | nindent 4 }}
 spec:
+  {{- if (.Values.hub.schedulerName) }}
+  schedulerName: {{ .Values.hub.schedulerName }}
+  {{- end}}
+
   securityContext:
     {{- toYaml .Values.hub.podSecurityContext | nindent 4 }}
   {{- if .Values.hub.pullSecrets }}

--- a/charts/zalenium/values.yaml
+++ b/charts/zalenium/values.yaml
@@ -75,6 +75,12 @@ hub:
   serviceAnnotations: {}
 
   # This enables using a custom scheduler for both hub and browser pods
+  # This could be useful to have a cost effective pod distribution with
+  # warmmed up browsers in k8s nodes by using a custom scheduler
+  # (i.e. by deploying a new one in your cluster) configured with
+  # MostRequestedPriority (https://kubernetes.io/docs/concepts/scheduling/)
+  # so that nodes tend to take all resources in nodes instead of flooding
+  # the nodes, easing downscaling.
   #schedulerName: null
 
   # Below we expose metrics to Prometheus.

--- a/charts/zalenium/values.yaml
+++ b/charts/zalenium/values.yaml
@@ -73,6 +73,10 @@ hub:
   # Annotations to be added to the service.
   ##
   serviceAnnotations: {}
+
+  # This enables using a custom scheduler for both hub and browser pods
+  #schedulerName: null
+
   # Below we expose metrics to Prometheus.
   #   prometheus.io/path: /metrics
   #   prometheus.io/scrape: "true"

--- a/src/main/java/de/zalando/ep/zalenium/container/kubernetes/PodConfiguration.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/kubernetes/PodConfiguration.java
@@ -36,6 +36,7 @@ public class PodConfiguration {
     private OwnerReference ownerReference;
     private PodSecurityContext podSecurityContext;
     private SecurityContext containerSecurityContext;
+    private String schedulerName;
 
     public String getNodePort() {
         return nodePort;
@@ -145,5 +146,13 @@ public class PodConfiguration {
 
     public void setContainerSecurityContext(SecurityContext containerSecurityContext) {
         this.containerSecurityContext = containerSecurityContext;
+    }
+
+    public String getSchedulerName() {
+        return schedulerName;
+    }
+
+    public void setSchedulerName(String schedulerName) {
+        this.schedulerName = schedulerName;
     }
 }

--- a/src/test/java/de/zalando/ep/zalenium/container/kubernetes/PodConfigurationTest.java
+++ b/src/test/java/de/zalando/ep/zalenium/container/kubernetes/PodConfigurationTest.java
@@ -163,4 +163,12 @@ public class PodConfigurationTest {
         podConfiguration.setContainerSecurityContext(securityContext);
         assertThat(podConfiguration.getContainerSecurityContext(), is(securityContext));
     }
+
+    @Test
+    public void testSetSchedulerName() {
+        final String schedulerName = "custom-scheduler";
+        podConfiguration.setSchedulerName(schedulerName);
+        assertThat(podConfiguration.getSchedulerName(), is(schedulerName));
+    }
+
 }

--- a/src/test/java/de/zalando/ep/zalenium/util/KubernetesContainerMock.java
+++ b/src/test/java/de/zalando/ep/zalenium/util/KubernetesContainerMock.java
@@ -103,6 +103,7 @@ public class KubernetesContainerMock {
                 .withVolumes(videosVolume, generalVolume)
                 .withHostAliases(hostAlias)
                 .withNodeSelector(nodeSelector)
+                .withSchedulerName("custom-scheduler")
                 .build();
         zaleniumPod.setSpec(zaleniumPodSpec);
 


### PR DESCRIPTION
### Description
This change allows using a custom scheduler in EKS both for the hub and for the bootstrapped browsers.

### Motivation and Context
In some cloud platforms like EKS o GKE, the scheduling algorithm performed by the default scheduler of k8s cannot be tuned. We have found that in order to have reasonable dynamic up scaling and down scaling of the cluster when you have warmed pods, and high varying browser concurrency (with changes from 20 browsers to up to 400), you need to use [`MostRequestedPriority`](https://kubernetes.io/docs/concepts/scheduling/) in order for nodes to get deleted by cluster autoscaler. This change enables setting a custom scheduler name for pods owned by zalenium so that this is possible.

### How Has This Been Tested?
We have made tests with a grid with 30 warmed up browsers in EKS, which initially required 4 nodes. **Without the changes**, we gave the grid big demand of 200 browsers, which brought up 20 nodes. After tests ended the grid was down scaled to 15 nodes, and the extra 11 nodes were never released (as they where occupied by warmed up browsers).
**With the changes**, we gave the grid big demand of 200 browsers, which brought up 20 nodes. After tests ended the grid was down scaled to 6 nodes. (I will PR latter with another solution to make them shrink down to the initial 4 nodes).

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.