### PR TITLE
Add configurations into helm template to support Virtual Node with AKS

### DIFF
--- a/charts/zalenium/templates/_pod-template.yaml
+++ b/charts/zalenium/templates/_pod-template.yaml
@@ -76,6 +76,18 @@ spec:
           value: {{ .Values.hub.memRequest | quote }}
         - name: ZALENIUM_KUBERNETES_MEMORY_LIMIT
           value: {{ .Values.hub.memLimit | quote }}
+        {{- if .Values.hub.seleniumNodeHost }}
+        - name: SELENIUM_NODE_HOST
+          value: {{ .Values.hub.seleniumNodeHost | quote }}
+        {{- end }}
+        {{- if .Values.hub.seleniumNodeSelector }}
+        - name: ZALENIUM_KUBERNETES_NODE_SELECTOR
+          value: {{ .Values.hub.seleniumNodeSelector | quote }}
+        {{- end }}
+        {{- if .Values.hub.seleniumTolerations }}
+        - name: ZALENIUM_KUBERNETES_TOLERATIONS
+          value: {{ .Values.hub.seleniumTolerations | quote }}
+        {{- end }}
         {{- if .Values.hub.basicAuth.enabled }}
         - name: GRID_USER
           valueFrom:
@@ -158,6 +170,10 @@ spec:
         - name: {{ $key | quote }}
           value: {{ $val | quote }}
         {{ end }}
+        {{- if .Values.hub.timeToWaitToStart }}
+        - name: TIME_TO_WAIT_TO_START
+          value: {{ .Values.hub.timeToWaitToStart | quote }}
+        {{- end }}
       args:
         - start
       resources:


### PR DESCRIPTION
To running well #1051, need to set some environment variables. Add some configurable variables into the helm template.

### Description
- Not affected to the existing generated template if NOT set the additional configurations.

| Parameter | Reason to add |
| --------- | ----------- |
|`hub.seleniumNodeHost`| Please refer to #1052|
|`hub.seleniumNodeSelector`|To run Selenium Node pods on Virtual Node.|
|`hub.seleniumTolerations`|To run Selenium Node pods on Virtual Node.|
|`hub.timeToWaitToStart` | Virtual Node needs the additional time to pull Selenium docker image every time. Also it has quotas limitation if create a lot Selenium pods on Virtual Node. <br>[Azure Container Instances quotas and region availability - Azure Container Instances - Microsoft Docs](https://docs.microsoft.com/en-us/azure/container-instances/container-instances-quotas)|

### Motivation and Context
Same as #1051 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested the followings by manually
  - [x] No changes in generated template using the existing `values.yaml`
  - [x]  Set added environment variables in generated template correctly if set them
  - [x]  Run Selenium pods on Virtual Node in AKS using additional variables, works well them 
    - Use custom build image, due to #1051 changes are not released yet...
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->