### PR TITLE
feature(): enable folderNames in name template

### DIFF
--- a/docs/_posts/2000-01-08-usage.md
+++ b/docs/_posts/2000-01-08-usage.md
@@ -212,6 +212,8 @@ Pass `? Only_active_sessions = true` at the end of the url. E.g.
     <code>myID_{browser}_{testStatus}</code> will result on video file name as "myID_chrome_COMPLETED.mp4".<br/>
 
     Default file name template is: {proxyName}_{testName}_{browser}_{platform}_{timestamp}_{testStatus}<br/>
+    
+    You can use '/' as separator in order to get the videos organized into different folders folder<br/>
 
     Example code in Java for the capability <code>testFileNameTemplate</code>.
 

--- a/src/main/java/de/zalando/ep/zalenium/dashboard/TestInformation.java
+++ b/src/main/java/de/zalando/ep/zalenium/dashboard/TestInformation.java
@@ -219,7 +219,7 @@ public class TestInformation {
                 .replace("{platform}", this.platform)
                 .replace("{timestamp}", commonProxyUtilities.getDateAndTimeFormatted(this.timestamp))
                 .replace("{testStatus}", getTestStatus().toString())
-                .replaceAll("[^a-zA-Z0-9]", "_");
+                .replaceAll("[^a-zA-Z0-9/\\-]", "_");
 
         this.fileName = FILE_NAME_TEMPLATE.replace("{fileName}", testNameNoExtension)
                 .replace("{fileExtension}", fileExtension);

--- a/src/main/java/de/zalando/ep/zalenium/proxy/DockerSeleniumRemoteProxy.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/DockerSeleniumRemoteProxy.java
@@ -638,8 +638,8 @@ public class DockerSeleniumRemoteProxy extends DefaultRemoteProxy {
                 testInformation.setFileExtension(fileExtension);
                 Path videoFile = Paths.get(String.format("%s/%s", testInformation.getVideoFolderPath(),
                         testInformation.getFileName()));
-                if (!Files.exists(Paths.get(testInformation.getVideoFolderPath()))) {
-                    Files.createDirectories(Paths.get(testInformation.getVideoFolderPath()));
+                if (!Files.exists(videoFile.getParent())) {
+                    Files.createDirectories(videoFile.getParent());
                 }
                 Files.copy(tarStream, videoFile);
                 CommonProxyUtilities.setFilePermissions(videoFile);


### PR DESCRIPTION
### Description
Enables videos and logs to be structured inside several folders

### Motivation and Context
To better evidences organization we would like to have the tests structured inside folders (for example `{date}/{application}/{browser}/{suite}/{test}.mp4`)

### How Has This Been Tested?
Simply setting `"zal:testFileNameTemplate"` capability to something like `20191205/{browser}/{platform}/mySuite/{testName}` makes both videos and logs be structured inside folders instead of in a plain structure. The dashboard keeps working as it relies in TestInformation provided data to build video and logs urls.

### Types of changes
- [x] New feature (non-breaking change which adds functionality).

### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
