### PR TITLE
feature(): enables using external selenium session id in test template

### DIFF
--- a/docs/_posts/2000-01-08-usage.md
+++ b/docs/_posts/2000-01-08-usage.md
@@ -206,6 +206,7 @@ Pass `? Only_active_sessions = true` at the end of the url. E.g.
     {browser} - The browser name<br/>
     {platform} - OS where test runs<br/>
     {timestamp} - Timestamp of test initialization<br/>
+    {seleniumSessionId} - The external sessionId provided to the test runner<br/>
     {testStatus} - Test result: COMPLETED|TIMEOUT|SUCCESS|FAILED<br/><br/>
 
     E.g.

--- a/src/main/java/de/zalando/ep/zalenium/dashboard/TestInformation.java
+++ b/src/main/java/de/zalando/ep/zalenium/dashboard/TestInformation.java
@@ -214,6 +214,7 @@ public class TestInformation {
 
         this.testNameNoExtension = this.testFileNameTemplate
                 .replace("{proxyName}", this.proxyName.toLowerCase())
+                .replace("{seleniumSessionId}", this.seleniumSessionId)
                 .replace("{testName}", getTestName())
                 .replace("{browser}", this.browser)
                 .replace("{platform}", this.platform)


### PR DESCRIPTION
### Description
This enables using the external session id in the video template file name.

### Motivation and Context
The external selenium session id enables having traceability from the tests logs in the test runner to the video and the logs on the zalenium side. We need this to build some link from our report to the test videos located inside Zalenium for faster and easier test fail diagnostic. We cannot rely in any other existing information (like test name) because our test runner retries automatically the failures in different process forks which makes it really difficult to have univoque no overlapping references to videos.

### How Has This Been Tested?
We added `{seleniumSessionId}` to the `zal:testFileNameTemplate` capability and verified that the external session id provided to our test runner matches the one in the name of the video.

### Types of changes
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
