### PR TITLE
feature(k8s): enable only adding some videos to persisted volume

### DIFF
--- a/charts/zalenium/templates/_pod-template.yaml
+++ b/charts/zalenium/templates/_pod-template.yaml
@@ -164,7 +164,7 @@ spec:
         {{- toYaml .Values.hub.resources | nindent 8 }}
       volumeMounts:
         - name: {{ template "zalenium.fullname" . }}-videos
-          mountPath: /home/seluser/videos
+          mountPath: /home/seluser/videos{{ .Values.persistence.video.folder }}
         - name: {{ template "zalenium.fullname" . }}-data
           mountPath: /tmp/mounted
 {{- if .Values.hostAliases }}

--- a/charts/zalenium/values.yaml
+++ b/charts/zalenium/values.yaml
@@ -167,6 +167,11 @@ persistence:
     accessMode: ReadWriteOnce
     size: 10Gi
 
+    ## Set this if you want only to use a volume to persist videos for an specific
+    ## build name. Note they will not show in the dashboard after restarts, but the
+    ## videos and logs will remain there.
+    folder: ""
+
 ingress:
   enabled: false
   tls: false

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -391,6 +391,8 @@ COPY zalenium.sh \
  /home/seluser/
 COPY scm-source.json /
 
+RUN mkdir /home/seluser/videos
+
 #-----------------#
 # Fix perms again #
 #-----------------#

--- a/src/main/java/de/zalando/ep/zalenium/container/kubernetes/KubernetesContainerClient.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/kubernetes/KubernetesContainerClient.java
@@ -197,10 +197,9 @@ public class KubernetesContainerClient implements ContainerClient {
     private void discoverFolderMounts() {
         List<VolumeMount> volumeMounts = zaleniumPod.getSpec().getContainers().get(0).getVolumeMounts();
 
-        List<VolumeMount> validMounts = new ArrayList<>();
-        volumeMounts.stream()
-                .filter(volumeMount -> !Arrays.asList(PROTECTED_NODE_MOUNT_POINTS).contains(volumeMount.getMountPath()))
-                .forEach(validMounts::add);
+        List<VolumeMount> validMounts = volumeMounts.stream()
+                .filter(volumeMount -> !Arrays.asList(PROTECTED_NODE_MOUNT_POINTS).stream().anyMatch(path -> volumeMount.getMountPath().startsWith(path)))
+                .collect(Collectors.toList());
 
         // Look through the volume mounts to see if the shared folder is mounted
         if (!validMounts.isEmpty()) {


### PR DESCRIPTION
### Description
This enables changing the mount path of the videos volume in eks.

### Motivation and Context
For auditing purposes (due to legal requirement) we need to save evidences (videos) of tests executed prior to deployment to some environments for a large amount of time (>2 years). We execute plenty of tests that we don't need the videos to be persisted. With this change, by adding the `zal:build` capability we are able to make those test evidences end in an specific folder inside `/home/seluser/video` called `evidences`. We can take advantage of the current video PVC to provide an NFS to S3 FileGateway volume so that the videos of our interest end up in an S3 bucket. We don't mind loosing the videos in the dashboard upon servers restarts (although if you want we could provide another optional PVC for the purpose of this PR, we did not in shake of getting the minimal code impact to the project). 

### How Has This Been Tested?
We created and NFS to S3 File Gateway Claim and added it to our helm by using the values file and the properties for that purpose. The dashboard keep showing the videos and logs properly.

### Types of changes
- [X] New feature (non-breaking change which adds functionality)

### Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] All new and existing tests passed.
