### PR TITLE
Kubernetes/Helm: Fix typo in Pod Template

### DIFF
--- a/charts/zalenium/templates/_pod-template.yaml
+++ b/charts/zalenium/templates/_pod-template.yaml
@@ -11,7 +11,7 @@ spec:
 
   securityContext:
     {{- toYaml .Values.hub.podSecurityContext | nindent 4 }}
-  {{- if .Values.hub.pullSecrets }}
+  {{- if .Values.hub.imagePullSecret }}
   imagePullSecrets:
     - name: {{ .Values.hub.imagePullSecret }}
   {{- end}}


### PR DESCRIPTION
Currently the `imagePullSecret` is being ignored when you set it in the `values.yaml`. This typo fixes that.

### Description
Fixed the typo in pod template.

### Motivation and Context
Fixes the problem that imagePullSecrets are not being picked up from the helm chart

### How Has This Been Tested?
Ran the changed version locally, now it picks up a set imagePullSecrets

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->