### PR TITLE
Start stop video by cookie (#1132)

### DIFF
--- a/docs/_posts/2000-01-08-usage.md
+++ b/docs/_posts/2000-01-08-usage.md
@@ -331,6 +331,42 @@ Thanks [adrichem](https://github.com/adrichem) for implementing this feature! Mo
 
 </details>    
 
+#### Change video recording status while in session
+<details>
+    <summary>Click for details.</summary>
+
+    <div class="container m-2 p-2">
+    It is possible to enable or disable video recording while the test is running regardless of what is setup when the session starts.
+    This is done by sending a cookie with the name <code>zaleniumVideo</code> with a value of <code>true</code> (to enable recording) 
+    or false (to disable recording). Disabling recording while it is originally enable will result in a new video file. This can be useful 
+    when you have multiple tests in one session and want to split up each test in its own file. This feature is only available with elgalu/selenium.
+    Here is an example in Java:
+
+{% highlight java %}
+    Cookie cookie = new Cookie("zaleniumVideo", "true");
+    webDriver.manage().addCookie(cookie);
+{% endhighlight %}
+
+    </div>
+
+</details> 
+
+#### Change test file name while in session
+<details>
+    <summary>Click for details.</summary>
+
+    <div class="container m-2 p-2">
+    A video file name can be changed in session by sending a cookie with the name <code>zaleniumTestName</code> with any value. 
+    This can be useful when coupling with <code>zaleniumVideo</code> to give each split video a custom name. Here is an example in Java:
+
+{% highlight java %}
+    Cookie cookie = new Cookie("zaleniumTestName", "anyName");
+    webDriver.manage().addCookie(cookie);
+{% endhighlight %}
+
+    </div>
+
+</details>
 
 ***
 

--- a/src/main/java/de/zalando/ep/zalenium/dashboard/TestInformation.java
+++ b/src/main/java/de/zalando/ep/zalenium/dashboard/TestInformation.java
@@ -240,6 +240,8 @@ public class TestInformation {
     public JsonObject getMetadata() { return this.metadata;}
     public void setMetadata(JsonObject metadata) { this.metadata = metadata;}
 
+    public void setTestName(String name) { this.testName = name;}
+
     public boolean equals(Object obj) {
         if (obj == null) return false;
         if (obj == this) return true;

--- a/src/main/java/de/zalando/ep/zalenium/proxy/DockerSeleniumRemoteProxy.java
+++ b/src/main/java/de/zalando/ep/zalenium/proxy/DockerSeleniumRemoteProxy.java
@@ -104,6 +104,7 @@ public class DockerSeleniumRemoteProxy extends DefaultRemoteProxy {
     private long cleanupStartedTime = 0;
     private AtomicBoolean timedOut = new AtomicBoolean(false);
     private long timeRegistered = System.currentTimeMillis();
+    private boolean stopRecordingByCookie = false;
 
     public DockerSeleniumRemoteProxy(RegistrationRequest request, GridRegistry registry) {
         super(request, registry);
@@ -323,6 +324,27 @@ public class DockerSeleniumRemoteProxy extends DefaultRemoteProxy {
                         processContainerAction(DockerSeleniumContainerAction.CLEAN_NOTIFICATION, getContainerId());
                         processContainerAction(DockerSeleniumContainerAction.SEND_NOTIFICATION, messageCommand,
                                 getContainerId());
+                    }
+                    if ("zaleniumVideo".equalsIgnoreCase(cookieName)) {
+                        boolean recordVideo = Boolean.parseBoolean(cookie.get("value").getAsString());
+                        if (recordVideo && !isVideoRecordingEnabled()) {
+                            setVideoRecordingEnabledSession(true);
+                            testInformation.setVideoRecorded(true);
+                            stopRecordingByCookie = false;
+                            videoRecording(DockerSeleniumContainerAction.START_RECORDING);
+                        } else if (!recordVideo && isVideoRecordingEnabled()){
+                            stopRecordingByCookie = true;
+                            videoRecording(DockerSeleniumContainerAction.STOP_RECORDING);
+                            setVideoRecordingEnabledSession(false);
+                            testInformation.setVideoRecorded(false);
+                        }
+                    }
+                    if ("zaleniumTestName".equalsIgnoreCase(cookieName)) {
+                        String newTestName = cookie.get("value").getAsString();
+                        if (!newTestName.isEmpty()) {
+                            testName = newTestName;
+                            testInformation.setTestName(testName);
+                        }
                     }
                     else if(CommonProxyUtilities.metadataCookieName.equalsIgnoreCase(cookieName)) {
                         JsonParser jsonParser = new JsonParser();
@@ -632,6 +654,9 @@ public class DockerSeleniumRemoteProxy extends DefaultRemoteProxy {
         if (keepVideoAndLogs()) {
             if (DockerSeleniumContainerAction.STOP_RECORDING == action) {
                 copyVideos(containerId);
+                if (stopRecordingByCookie) {
+                    DashboardCollection.updateDashboard(testInformation);
+                }
             }
             if (DockerSeleniumContainerAction.TRANSFER_LOGS == action) {
                 copyLogs(containerId);
@@ -657,6 +682,21 @@ public class DockerSeleniumRemoteProxy extends DefaultRemoteProxy {
                         testInformation.getFileName()));
                 if (!Files.exists(videoFile.getParent())) {
                     Files.createDirectories(videoFile.getParent());
+                }
+
+                //For multiple recording in one session, add '_{count}' to the test name
+                int count = 1;
+                while (Files.exists(videoFile)) {
+                    if (testInformation.getTestName().contains("_")) {
+                        testName = testInformation.getTestName().substring(0, testInformation.getTestName().length() - 2) + "_" + count;
+                    } else {
+                        testName = testInformation.getTestName() + "_" + count;
+                    }
+                    testInformation.setTestName(testName);
+                    testInformation.setFileExtension(fileExtension);
+                    videoFile = Paths.get(String.format("%s/%s", testInformation.getVideoFolderPath(),
+                            testInformation.getFileName()));
+                    count++;
                 }
                 Files.copy(entry.get(), videoFile);
                 CommonProxyUtilities.setFilePermissions(videoFile);

--- a/src/test/java/de/zalando/ep/zalenium/it/ParallelIT.java
+++ b/src/test/java/de/zalando/ep/zalenium/it/ParallelIT.java
@@ -201,7 +201,7 @@ public class ParallelIT  {
 
         // Reset dashboard
         getWebDriver().get(String.format("http://%s:%s/dashboard", hostIpAddress, ZALENIUM_PORT));
-        getWebDriver().manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+//        getWebDriver().manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
         getWebDriver().findElement(By.id("resetButton")).click();
         getWebDriver().findElement(By.id("resetModalConfirm")).click();
 

--- a/src/test/java/de/zalando/ep/zalenium/it/ParallelIT.java
+++ b/src/test/java/de/zalando/ep/zalenium/it/ParallelIT.java
@@ -194,7 +194,7 @@ public class ParallelIT  {
     }
 
     @Test(dataProvider = "browsersAndPlatformsForLivePreview")
-    public void splitVideoRecordingOfOneSessionIntoMultipleFiles(DesiredCapabilities desiredCapabilities) {
+    public void splitVideoRecordingOfOneSessionIntoMultipleFiles(DesiredCapabilities desiredCapabilities) throws InterruptedException {
 
         NetworkUtils networkUtils = new NetworkUtils();
         String hostIpAddress = networkUtils.getIp4NonLoopbackAddressOfThisMachine().getHostAddress();
@@ -222,6 +222,9 @@ public class ParallelIT  {
 
         // Go to the dashboard
         getWebDriver().get(String.format("http://%s:%s/dashboard", hostIpAddress, ZALENIUM_PORT));
+        System.out.println(getWebDriver().getCurrentUrl());
+        Thread.sleep(1000 * 10);
+        System.out.println(getWebDriver().getPageSource());
 
         //Wait for elements
         new WebDriverWait(getWebDriver(), 60).until(

--- a/src/test/java/de/zalando/ep/zalenium/it/ParallelIT.java
+++ b/src/test/java/de/zalando/ep/zalenium/it/ParallelIT.java
@@ -8,6 +8,8 @@ import org.openqa.selenium.net.NetworkUtils;
 import org.openqa.selenium.remote.BrowserType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -35,7 +37,7 @@ public class ParallelIT  {
     private static final String testingBotIntegration = "testingBot";
     private static final String crossBrowserTestingIntegration = "crossBrowserTesting";
     private static final String lambdaTestIntegration = "lambdaTest";
-    
+
     // Zalenium setup variables
     private static final String ZALENIUM_HOST = System.getenv("ZALENIUM_GRID_HOST") != null ?
             System.getenv("ZALENIUM_GRID_HOST") : "localhost";
@@ -220,6 +222,10 @@ public class ParallelIT  {
 
         // Go to the dashboard
         getWebDriver().get(String.format("http://%s:%s/dashboard", hostIpAddress, ZALENIUM_PORT));
+
+        //Wait for elements
+        new WebDriverWait(getWebDriver(), 60).until(
+            ExpectedConditions.numberOfElementsToBe(By.cssSelector("a.list-group-item-action"), 2));
 
         assertThat(getWebDriver().findElements(By.cssSelector(("a.list-group-item-action"))).size(), is(2));
     }

--- a/src/test/java/de/zalando/ep/zalenium/it/ParallelIT.java
+++ b/src/test/java/de/zalando/ep/zalenium/it/ParallelIT.java
@@ -201,7 +201,7 @@ public class ParallelIT  {
 
         // Reset dashboard
         getWebDriver().get(String.format("http://%s:%s/dashboard", hostIpAddress, ZALENIUM_PORT));
-//        getWebDriver().manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+        getWebDriver().manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
         getWebDriver().findElement(By.id("resetButton")).click();
         getWebDriver().findElement(By.id("resetModalConfirm")).click();
 

--- a/src/test/java/de/zalando/ep/zalenium/it/ParallelIT.java
+++ b/src/test/java/de/zalando/ep/zalenium/it/ParallelIT.java
@@ -194,7 +194,7 @@ public class ParallelIT  {
     }
 
     @Test(dataProvider = "browsersAndPlatformsForLivePreview")
-    public void splitVideoRecordingOfOneSessionIntoMultipleFiles(DesiredCapabilities desiredCapabilities) throws InterruptedException {
+    public void splitVideoRecordingOfOneSessionIntoMultipleFiles(DesiredCapabilities desiredCapabilities) {
 
         NetworkUtils networkUtils = new NetworkUtils();
         String hostIpAddress = networkUtils.getIp4NonLoopbackAddressOfThisMachine().getHostAddress();
@@ -222,9 +222,6 @@ public class ParallelIT  {
 
         // Go to the dashboard
         getWebDriver().get(String.format("http://%s:%s/dashboard", hostIpAddress, ZALENIUM_PORT));
-        System.out.println(getWebDriver().getCurrentUrl());
-        Thread.sleep(1000 * 10);
-        System.out.println(getWebDriver().getPageSource());
 
         //Wait for elements
         new WebDriverWait(getWebDriver(), 60).until(


### PR DESCRIPTION
* Add feature to start or stop video recording using cookie

Per #490, video recording can be started, if disabled, or stopped, if enabled, by sending cookie named 'zaleniumVideo'. This is beneficial when multiple tests run in the same session.

Additionally to assist with identifying tests in the dashboard, a cookie named 'zaleniumTestName' can be passed in to set the test name. This name will appear in the dashboard. If name already exists, a count will be appended to the name.

* Add feature to start or stop video recording using cookie Part 2

Adding documentation and integration test along with small change in duplicate file naming logic. Also, revert back the logic of the keepVideoAndLogs method

Co-authored-by: Chanatan Charnkijtawarush <ccharnkij@gmail.com>


**Thanks for contributing to Zalenium! Please give us as much information as possible to merge this PR
quickly.**

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->