### PR TITLE
Start stop video by cookie (#1144)

### DIFF
--- a/docs/_posts/2000-01-08-usage.md
+++ b/docs/_posts/2000-01-08-usage.md
@@ -331,6 +331,42 @@ Thanks [adrichem](https://github.com/adrichem) for implementing this feature! Mo
 
 </details>    
 
+#### Change video recording status while in session
+<details>
+    <summary>Click for details.</summary>
+
+    <div class="container m-2 p-2">
+    It is possible to enable or disable video recording while the test is running regardless of what is setup when the session starts.
+    This is done by sending a cookie with the name <code>zaleniumVideo</code> with a value of <code>true</code> (to enable recording) 
+    or false (to disable recording). Disabling recording while it is originally enable will result in a new video file. This can be useful 
+    when you have multiple tests in one session and want to split up each test in its own file. This feature is only available with elgalu/selenium.
+    Here is an example in Java:
+
+{% highlight java %}
+    Cookie cookie = new Cookie("zaleniumVideo", "true");
+    webDriver.manage().addCookie(cookie);
+{% endhighlight %}
+
+    </div>
+
+</details> 
+
+#### Change test file name while in session
+<details>
+    <summary>Click for details.</summary>
+
+    <div class="container m-2 p-2">
+    A video file name can be changed in session by sending a cookie with the name <code>zaleniumTestName</code> with any value. 
+    This can be useful when coupling with <code>zaleniumVideo</code> to give each split video a custom name. Here is an example in Java:
+
+{% highlight java %}
+    Cookie cookie = new Cookie("zaleniumTestName", "anyName");
+    webDriver.manage().addCookie(cookie);
+{% endhighlight %}
+
+    </div>
+
+</details>
 
 ***
 

--- a/src/main/java/de/zalando/ep/zalenium/dashboard/TestInformation.java
+++ b/src/main/java/de/zalando/ep/zalenium/dashboard/TestInformation.java
@@ -240,6 +240,8 @@ public class TestInformation {
     public JsonObject getMetadata() { return this.metadata;}
     public void setMetadata(JsonObject metadata) { this.metadata = metadata;}
 
+    public void setTestName(String name) { this.testName = name;}
+
     public boolean equals(Object obj) {
         if (obj == null) return false;
         if (obj == this) return true;


### PR DESCRIPTION
* Add feature to start or stop video recording using cookie

Per #490, video recording can be started, if disabled, or stopped, if enabled, by sending cookie named 'zaleniumVideo'. This is beneficial when multiple tests run in the same session.

Additionally to assist with identifying tests in the dashboard, a cookie named 'zaleniumTestName' can be passed in to set the test name. This name will appear in the dashboard. If name already exists, a count will be appended to the name.

* Add feature to start or stop video recording using cookie Part 2

Adding documentation and integration test along with small change in duplicate file naming logic. Also, revert back the logic of the keepVideoAndLogs method

* Add feature to start or stop video recording using cookie Part 3

Add wait for items to appear in the dashboard for the IT

* Add feature to start or stop video recording using cookie Part 4

Modify IT and add condition to prevent multiple cleanupNode

Co-authored-by: Chanatan Charnkijtawarush <ccharnkij@gmail.com>


**Thanks for contributing to Zalenium! Please give us as much information as possible to merge this PR
quickly.**

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->