### PR TITLE
Add default TESTINGBOT_TUNNEL_ID=zalenium

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -356,6 +356,7 @@ ENV ZAL_VER="${project.build.finalName}" \
     TESTINGBOT_TUNNEL_OPTS="--se-port 4447" \
     TESTINGBOT_TUNNEL="false" \
     TESTINGBOT_WAIT_TIMEOUT="2m" \
+    TESTINGBOT_TUNNEL_ID="zalenium" \
     CBT_TUNNEL_ID="zalenium" \
     CBT_TUNNEL="false" \
     LT_TUNNEL_ID="zalenium" \

--- a/scripts/start-testingbot.sh
+++ b/scripts/start-testingbot.sh
@@ -16,6 +16,7 @@ die () {
 # Required params
 [ -z "${TESTINGBOT_KEY}" ] && die "Required env var TESTINGBOT_KEY"
 [ -z "${TESTINGBOT_SECRET}" ] && die "Required env var TESTINGBOT_SECRET"
+[ -z "${TESTINGBOT_TUNNEL_ID}" ] && die "Required env var TESTINGBOT_TUNNEL_ID"
 [ -z "${TESTINGBOT_TUNNEL_OPTS}" ] && die "Required env var TESTINGBOT_TUNNEL_OPTS"
 
 # Wait for this process dependencies
@@ -26,6 +27,7 @@ die () {
 java -jar /usr/local/bin/testingbot-tunnel.jar \
   ${TESTINGBOT_KEY} \
   ${TESTINGBOT_SECRET} \
+  --tunnel-identifier "${TESTINGBOT_TUNNEL_ID}" \
   --se-port 4447 ${TESTINGBOT_TUNNEL_OPTS} > ${TESTINGBOT_LOG_FILE} 2>&1 &
 TESTINGBOT_TUNNEL_PID=$!
 


### PR DESCRIPTION
### Description
This commit adds a `--tunnel-identifier` to TestingBot's start tunnel command.

### Motivation and Context
This way, users can easily use the tunnel with a tunnel-identifier.

### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.