### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,31 +14,31 @@ jobs:
       if: type = pull_request
       script:
       - docker pull elgalu/selenium
-      - travis_retry ./run_integration_tests.sh sauceLabs
+      - ./run_integration_tests.sh sauceLabs
 
     - env: step=browserStack
       if: type = pull_request
       script:
         - docker pull elgalu/selenium
-        - travis_retry ./run_integration_tests.sh browserStack
+        - ./run_integration_tests.sh browserStack
 
     - env: step=crossBrowserTesting
       if: type = pull_request
       script:
         - docker pull elgalu/selenium
-        - travis_retry ./run_integration_tests.sh crossBrowserTesting
+        - ./run_integration_tests.sh crossBrowserTesting
 
     - env: step=testingBot
       if: type = pull_request
       script:
         - docker pull elgalu/selenium
-        - travis_retry ./run_integration_tests.sh testingBot
+        - ./run_integration_tests.sh testingBot
 
     - env: step=lambdaTest
       if: type = pull_request
       script:
         - docker pull elgalu/selenium
-        - travis_retry ./run_integration_tests.sh lambdaTest
+        - ./run_integration_tests.sh lambdaTest
 
     - env: step=dockerCompose
       if: type = pull_request
@@ -47,7 +47,7 @@ jobs:
       - curl -L https://github.com/docker/compose/releases/download/1.21.0/docker-compose-`uname -s`-`uname -m` > docker-compose
       - chmod +x docker-compose
       - sudo mv docker-compose /usr/local/bin
-      - travis_retry ./run_integration_tests.sh dockerCompose
+      - ./run_integration_tests.sh dockerCompose
 
     - env: step=unitTests
       script:
@@ -64,7 +64,7 @@ jobs:
       if: type = pull_request
       script:
       - docker pull elgalu/selenium
-      - travis_retry ./kubernetes/minikube-ci-initialize.sh
+      - ./kubernetes/minikube-ci-initialize.sh
       - mvn clean package -Pbuild-docker-image -DskipTests=true
       - cd target && docker build -t dosel/zalenium:latest . && cd ..
       - ./kubernetes/start-zalenium-in-minikube.sh
@@ -75,3 +75,7 @@ jobs:
       script:
       - ./gen-scm-source.sh
       - ./push_image.sh
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

Does travis_retry really solve the build issues? According to the data in paper [An empirical study of the long duration of continuous integration builds](https://dl.acm.org/doi/10.1007/s10664-019-09695-9), travis_retry can only solve 3% of the build failures. And it may cause unstable build and increase build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
