### PR TITLE
sauce labs has dropped support for older versions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -260,7 +260,7 @@ RUN if [ "${kubernetesSlimVersion}" = "false" ]; then \
 # ------------------------#
 # https://docs.saucelabs.com/reference/sauce-connect/
 # Layer size: medium: ~13 MB
-ENV SAUCE_CONN_VER="sc-4.5.3-linux" \
+ENV SAUCE_CONN_VER="sc-4.6.5-linux" \
     SAUCE_CONN_DOWN_URL="https://saucelabs.com/downloads"
 RUN cd /tmp \
   && wget -nv "${SAUCE_CONN_DOWN_URL}/${SAUCE_CONN_VER}.tar.gz" \


### PR DESCRIPTION
Changing sauce labs proxy connect version

### Description
<!--- Describe your changes in detail -->
sauce labs has dropped support for older versions as mentioned in the following document, https://changelog.saucelabs.com/en/sauce-connect-reminder-end-of-support-dates
So the latest version needs to be added, i.e. 4.6.5 (https://docs.saucelabs.com/secure-connections/sauce-connect/installation/index.html?utm_source=beamer&utm_medium=standalone&utm_campaign=Sauce-Connect-Reminder-End-of-Support-Dates&utm_content=textlink)

### Motivation and Context
Current version of sauce proxy connect will not work, while using tunnelling, hence new version needs to be updated.

### How Has This Been Tested?
Latest version of sauce connect proxy is working fine on my test zalenium server

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->