### PR TITLE
Fixing the docker images filter issue with ListImagesParam.byName method in getLatestDownloadedImage method

### DIFF
--- a/src/main/java/de/zalando/ep/zalenium/container/DockerContainerClient.java
+++ b/src/main/java/de/zalando/ep/zalenium/container/DockerContainerClient.java
@@ -263,7 +263,9 @@ public class DockerContainerClient implements ContainerClient {
     public String getLatestDownloadedImage(String imageName) {
         List<Image> images;
         try {
-            images = dockerClient.listImages(DockerClient.ListImagesParam.byName(imageName));
+            images = dockerClient.listImages(DockerClient.ListImagesParam.allImages())
+                    .stream().filter(image -> image.repoTags().stream().anyMatch(i -> i.contains(imageName)))
+                    .collect(Collectors.toList());
             if (images.isEmpty()) {
                 logger.error(nodeId + " A downloaded docker-selenium image was not found!");
                 return imageName;


### PR DESCRIPTION
**Thanks for contributing to Zalenium! Please give us as much information as possible to merge this PR
quickly.**

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
DockerClient.ListImagesParam.byName method was not filtering the images based on the image name. Rather it was giving all available docker images in system which in turn returns the first available image from the `getLatestDownloadedImage` method from the `DockerContainerClient` file. I have used java filtering to solve this issue.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As getLatestDownloadedImage method was return wrong image name, zalenium was starting the wrong container.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I have tested these changes locally as well as on our servers, which after the changes works perfectly fine.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->